### PR TITLE
fix #152 don't show workspaces page to unauthorized users

### DIFF
--- a/src/main/java/io/hexlet/typoreporter/config/SecurityConfig.java
+++ b/src/main/java/io/hexlet/typoreporter/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(authz -> authz
                 .requestMatchers(GET, "/webjars/**", "/widget/**", "/img/**").permitAll()
-                .requestMatchers("/", "/workspaces", "/login", "/signup", "/error").permitAll()
+                .requestMatchers("/", "/login", "/signup", "/error").permitAll()
                 .anyRequest().authenticated()
             )
             .formLogin(login -> login


### PR DESCRIPTION
Теперь при переходе на страницу сервиса требуется авторизация.

https://hexlet-correction-dont-show-workspaces.up.railway.app/

Правильно ли я поняла задачу и нужно ли еще что-то добавить?