### PR TITLE
[#181] fix workspace cards height

### DIFF
--- a/src/main/resources/templates/workspaces.html
+++ b/src/main/resources/templates/workspaces.html
@@ -6,10 +6,12 @@
 <main class="container">
     <div class="row row-cols-1 row-cols-md-3 g-4">
         <div class="col" th:each="wksInfo : ${wksInfoList}" th:object="${wksInfo}">
-            <div class="card">
+            <div class="card h-100">
                 <div class="card-body">
                     <h5 class="card-title" th:text="*{name}"></h5>
                     <p class="card-text" th:text="*{description}"></p>
+                </div>
+                <div class="card-footer bg-white border-top-0">
                     <a class="card-link" th:href="@{'/workspace/' + *{name}}" th:text="#{wks.info}"></a>
                     <a class="card-link" th:href="@{'/workspace/' + *{name} + '/typos'}" th:text="#{wks.typos}"></a>
                     <a class="card-link" th:href="@{'/workspace/' + *{name} + '/users'}" th:text="#{wks.users}"></a>


### PR DESCRIPTION
Fixed workspace cards height.
Height before:
![cards_before](https://github.com/Hexlet/hexlet-correction/assets/44774899/329962aa-3dfe-4171-9ab5-1aeeb8f859f3)
Height after:
![cards_after](https://github.com/Hexlet/hexlet-correction/assets/44774899/b91e9427-cfee-4d94-8ac5-6b1105e9e6cf)

