### PR TITLE
Add @Email annotation parameters to prevent invalid email

### DIFF
--- a/src/main/java/io/hexlet/typoreporter/service/dto/account/UpdateProfile.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/account/UpdateProfile.java
@@ -18,10 +18,10 @@ public class UpdateProfile {
     @AccountUsername
     private String username;
 
-    @Email
+    @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
     private String email;
 
-    @Email
+    @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
     private String confirmEmail;
 
     @NotBlank

--- a/src/main/java/io/hexlet/typoreporter/web/model/SignupAccountModel.java
+++ b/src/main/java/io/hexlet/typoreporter/web/model/SignupAccountModel.java
@@ -26,10 +26,10 @@ public class SignupAccountModel {
     @AccountUsername
     private String username;
 
-    @Email
+    @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
     private String email;
 
-    @Email
+    @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
     private String confirmEmail;
 
     @AccountPassword


### PR DESCRIPTION
#197 - В аннотациях @Email не были указаны регулярные выражения для проверки введенного email. Добавил к параметрам аннотации регулярное выражение и сообщение для ошибки, в случае неудачной проверки.