### PR TITLE
[#206] Fix sorting arrows

### DIFF
--- a/src/main/resources/templates/workspace/wks-typos.html
+++ b/src/main/resources/templates/workspace/wks-typos.html
@@ -96,7 +96,7 @@
                                            th:href="${typoStatus} != null ?
                                                 @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|pageUrl,${sortProp == 'pageUrl' && sortDir.isAscending() ? DESC : ASC}|, typoStatus=${typoStatus})}
                                                 : @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|pageUrl,${sortProp == 'pageUrl' && sortDir.isAscending() ? DESC : ASC}|)}">
-                                            <span th:text="#{url-page}"></span> <span>[[${sortProp == 'pageUrl' && sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
+                                            <span th:text="#{url-page}"></span> <span th:if="${sortProp == 'pageUrl'}">[[${sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
                                         </a>
                                     </th>
                                     <th scope="col">
@@ -104,7 +104,7 @@
                                            th:href="${typoStatus} != null ?
                                                 @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|reporterName,${sortProp == 'reporterName' && sortDir.isAscending() ? DESC : ASC}|, typoStatus=${typoStatus})}
                                                 : @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|reporterName,${sortProp == 'reporterName' && sortDir.isAscending() ? DESC : ASC}|)}">
-                                            <span th:text="#{reporter-name}"></span> <span>[[${sortProp == 'reporterName' && sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
+                                            <span th:text="#{reporter-name}"></span> <span th:if="${sortProp == 'reporterName'}">[[${sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
                                         </a>
                                     </th>
                                     <th scope="col">
@@ -112,7 +112,7 @@
                                            th:href="${typoStatus} != null ?
                                                 @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|createdDate,${sortProp == 'createdDate' && sortDir.isAscending() ? DESC : ASC}|, typoStatus=${typoStatus})}
                                                 : @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|createdDate,${sortProp == 'createdDate' && sortDir.isAscending() ? DESC : ASC}|)}">
-                                            <span th:text="#{date.created}"></span> <span>[[${sortProp == 'createdDate' && sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
+                                            <span th:text="#{date.created}"></span> <span th:if="${sortProp == 'createdDate'}">[[${sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
                                         </a>
                                     </th>
                                     <th scope="col">
@@ -120,7 +120,7 @@
                                            th:href="${typoStatus} != null ?
                                                 @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|modifiedDate,${sortProp == 'modifiedDate' && sortDir.isAscending() ? DESC : ASC}|, typoStatus=${typoStatus})}
                                                 : @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|modifiedDate,${sortProp == 'modifiedDate' && sortDir.isAscending() ? DESC : ASC}|)}">
-                                            <span th:text="#{date.modified}"></span> <span>[[${sortProp == 'modifiedDate' && sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
+                                            <span th:text="#{date.modified}"></span> <span  th:if="${sortProp == 'modifiedDate'}">[[${sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
                                         </a>
                                     </th>
                                     <th scope="col">
@@ -128,7 +128,7 @@
                                            th:href="${typoStatus} != null ?
                                                 @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|modifiedBy,${sortProp == 'modifiedBy' && sortDir.isAscending() ? DESC : ASC}|, typoStatus=${typoStatus})}
                                                 : @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|modifiedBy,${sortProp == 'modifiedBy' && sortDir.isAscending() ? DESC : ASC}|)}">
-                                            <span th:text="#{modified-by}"></span> <span>[[${sortProp == 'modifiedBy' && sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
+                                            <span th:text="#{modified-by}"></span> <span th:if="${sortProp == 'modifiedBy'}">[[${sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
                                         </a>
                                     </th>
                                     <th scope="col">
@@ -136,7 +136,7 @@
                                            th:href="${typoStatus} != null ?
                                                 @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|typoStatus,${sortProp == 'typoStatus' && sortDir.isAscending() ? DESC : ASC}|, typoStatus=${typoStatus})}
                                                 : @{'/workspace/' + ${wksName} + '/typos'(size=*{size},sort=|typoStatus,${sortProp == 'typoStatus' && sortDir.isAscending() ? DESC : ASC}|)}">
-                                            <span th:text="#{typo-status}"></span> <span>[[${sortProp == 'typoStatus' && sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
+                                            <span th:text="#{typo-status}"></span> <span th:if="${sortProp == 'typoStatus'}">[[${sortDir.isAscending() ? '&uArr;' : '&dArr;'}]]</span>
                                         </a>
                                     </th>
                                 </tr>


### PR DESCRIPTION
https://github.com/Hexlet/hexlet-correction/issues/205

Демо: https://hexlet-correction-filtration.onrender.com/

Стрелка теперь стоит только у того столбца, по которому выполняется сортировка
![image](https://github.com/Hexlet/hexlet-correction/assets/29205112/1d899583-d343-403d-b490-bd4302e191f1)
