### PR TITLE
[#174] Fix modifiedBy initial view

### DIFF
--- a/src/main/resources/templates/workspace/wks-typos.html
+++ b/src/main/resources/templates/workspace/wks-typos.html
@@ -152,7 +152,7 @@
                                         <td th:text="*{reporterName}"></td>
                                         <td th:text="*{createdDateAgo}"></td>
                                         <td th:text="*{modifiedDateAgo}"></td>
-                                        <td th:text="*{modifiedBy}"></td>
+                                        <td th:text="*{modifiedBy} != ${wksInfo.id} ? *{modifiedBy} : ''"></td>
                                         <td th:text="#{*{typoStatus}}"></td>
                                     </tr>
                                     <!-- Workspace typo table row collapsed part -->


### PR DESCRIPTION
https://github.com/Hexlet/hexlet-correction/issues/174

При добавлении опечатки, в столбце modifiedBy теперь пусто
![image](https://github.com/Hexlet/hexlet-correction/assets/29205112/ec26c1d1-a9ee-4fcc-8618-1241a3e61c46)
