### PR TITLE
Change workspace description validation rule

### DIFF
--- a/src/main/java/io/hexlet/typoreporter/domain/workspace/constraint/WorkspaceDescription.java
+++ b/src/main/java/io/hexlet/typoreporter/domain/workspace/constraint/WorkspaceDescription.java
@@ -10,8 +10,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@NotBlank
-@Size(min = 2, max = 1000)
+@Size(max = 1000)
 @Constraint(validatedBy = {})
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
Fixes #213

Сделал поле "Описание пространства" необязательным. Убрал проверку на минимальное количество символов. 