### PR TITLE
Implement date localization, data type change, and TypoRepository fix (#167)

### DIFF
--- a/src/main/java/io/hexlet/typoreporter/domain/AbstractAuditingEntity.java
+++ b/src/main/java/io/hexlet/typoreporter/domain/AbstractAuditingEntity.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @MappedSuperclass
@@ -28,7 +28,7 @@ public abstract class AbstractAuditingEntity implements Serializable {
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdDate;
+    private Instant createdDate;
 
     @LastModifiedBy
     @Column(nullable = false)
@@ -36,5 +36,5 @@ public abstract class AbstractAuditingEntity implements Serializable {
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime modifiedDate;
+    private Instant modifiedDate;
 }

--- a/src/main/java/io/hexlet/typoreporter/repository/TypoRepository.java
+++ b/src/main/java/io/hexlet/typoreporter/repository/TypoRepository.java
@@ -29,5 +29,6 @@ public interface TypoRepository extends JpaRepository<Typo, Long> {
         """)
     List<Pair<TypoStatus, Long>> getCountTypoStatusForWorkspaceName(String wksName);
 
-    Optional<Typo> getTopByWorkspaceNameOrderByCreatedDate(String wksName);
+    Optional<Typo> findFirstByWorkspaceNameOrderByCreatedDateDesc(String wksName);
+
 }

--- a/src/main/java/io/hexlet/typoreporter/service/TypoService.java
+++ b/src/main/java/io/hexlet/typoreporter/service/TypoService.java
@@ -103,7 +103,7 @@ public class TypoService {
 
     @Transactional(readOnly = true)
     public Optional<TypoInfo> getLastTypoByWorkspaceName(final String wksName) {
-        return repository.getTopByWorkspaceNameOrderByCreatedDate(wksName)
+        return repository.findFirstByWorkspaceNameOrderByCreatedDateDesc(wksName)
             .map(typoMapper::toTypoInfo);
     }
 

--- a/src/main/java/io/hexlet/typoreporter/service/dto/typo/ReportedTypo.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/typo/ReportedTypo.java
@@ -1,6 +1,6 @@
 package io.hexlet.typoreporter.service.dto.typo;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record ReportedTypo(
     Long id,
@@ -11,7 +11,7 @@ public record ReportedTypo(
     String textTypo,
     String textAfterTypo,
     String createdBy,
-    LocalDateTime createdDate
+    Instant createdDate
 ) {
 
 }

--- a/src/main/java/io/hexlet/typoreporter/service/dto/typo/TypoInfo.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/typo/TypoInfo.java
@@ -2,7 +2,7 @@ package io.hexlet.typoreporter.service.dto.typo;
 
 import io.hexlet.typoreporter.domain.typo.TypoStatus;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record TypoInfo(
     Long id,
@@ -16,10 +16,10 @@ public record TypoInfo(
     TypoStatus typoStatus,
     String createdBy,
     String createdDateAgo,
-    LocalDateTime createdDate,
+    Instant createdDate,
     String modifiedBy,
     String modifiedDateAgo,
-    LocalDateTime modifiedDate
+    Instant modifiedDate
 ) {
 
 }

--- a/src/main/java/io/hexlet/typoreporter/service/dto/workspace/WorkspaceInfo.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/workspace/WorkspaceInfo.java
@@ -1,6 +1,7 @@
 package io.hexlet.typoreporter.service.dto.workspace;
 
-import java.time.LocalDateTime;
+
+import java.time.Instant;
 
 public record WorkspaceInfo(
     Long id,
@@ -8,10 +9,10 @@ public record WorkspaceInfo(
     String url,
     String description,
     String createdBy,
-    LocalDateTime createdDate,
+    Instant createdDate,
     String createdDateAgo,
     String modifiedBy,
-    LocalDateTime modifiedDate,
+    Instant modifiedDate,
     String modifiedDateAgo
 ) {
 

--- a/src/main/java/io/hexlet/typoreporter/service/mapper/TypoMapper.java
+++ b/src/main/java/io/hexlet/typoreporter/service/mapper/TypoMapper.java
@@ -8,8 +8,9 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.ocpsoft.prettytime.PrettyTime;
+import org.springframework.context.i18n.LocaleContextHolder;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Mapper
 public interface TypoMapper {
@@ -26,7 +27,8 @@ public interface TypoMapper {
     ReportedTypo toReportedTypo(Typo source);
 
     @Named(value = "mapToPrettyDateAgo")
-    default String getDateAgoAsString(LocalDateTime date) {
+    default String getDateAgoAsString(Instant date) {
+        prettyTime.setLocale(LocaleContextHolder.getLocale());
         return prettyTime.format(date);
     }
 }

--- a/src/main/java/io/hexlet/typoreporter/service/mapper/WorkspaceMapper.java
+++ b/src/main/java/io/hexlet/typoreporter/service/mapper/WorkspaceMapper.java
@@ -7,8 +7,9 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.ocpsoft.prettytime.PrettyTime;
+import org.springframework.context.i18n.LocaleContextHolder;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Mapper
 public interface WorkspaceMapper {
@@ -22,7 +23,8 @@ public interface WorkspaceMapper {
     WorkspaceInfo toWorkspaceInfo(Workspace source);
 
     @Named(value = "mapToPrettyDateAgo")
-    default String getDateAgoAsString(LocalDateTime date) {
+    default String getDateAgoAsString(Instant date) {
+        prettyTime.setLocale(LocaleContextHolder.getLocale());
         return prettyTime.format(date);
     }
 }

--- a/src/main/java/io/hexlet/typoreporter/web/WorkspaceController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/WorkspaceController.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.ocpsoft.prettytime.PrettyTime;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -45,6 +46,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -315,7 +317,8 @@ public class WorkspaceController {
     private void getLastTypoDataToModel(final Model model, final String wksName) {
         final var createdDate = typoService.getLastTypoByWorkspaceName(wksName).map(TypoInfo::createdDate);
         model.addAttribute("lastTypoCreatedDate", createdDate);
-        model.addAttribute("lastTypoCreatedDateAgo", createdDate.map(new PrettyTime()::format));
+        Locale locale = LocaleContextHolder.getLocale();
+        model.addAttribute("lastTypoCreatedDateAgo", createdDate.map(new PrettyTime(locale)::format));
     }
 
     private List<Account> getNonLinkedAccounts(Collection<Account> allAccounts, Collection<Account> linkedAccounts) {

--- a/src/main/java/io/hexlet/typoreporter/web/WorkspaceSettingsController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/WorkspaceSettingsController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.ocpsoft.prettytime.PrettyTime;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.Base64;
+import java.util.Locale;
 
 @Slf4j
 @Controller
@@ -71,6 +73,7 @@ public class WorkspaceSettingsController {
     private void getLastTypoDataToModel(final Model model, final String wksName) {
         final var createdDate = typoService.getLastTypoByWorkspaceName(wksName).map(TypoInfo::createdDate);
         model.addAttribute("lastTypoCreatedDate", createdDate);
-        model.addAttribute("lastTypoCreatedDateAgo", createdDate.map(new PrettyTime()::format));
+        Locale locale = LocaleContextHolder.getLocale();
+        model.addAttribute("lastTypoCreatedDateAgo", createdDate.map(new PrettyTime(locale)::format));
     }
 }

--- a/src/main/resources/db/changelog/changesets/2023/10/2023-10-16-change-time-format-to-timestamp-with-time-zone.xml
+++ b/src/main/resources/db/changelog/changesets/2023/10/2023-10-16-change-time-format-to-timestamp-with-time-zone.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd"
+    objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+    <changeSet id="2023-10-16-change-time-format-to-timestamp-with-time-zone-1" author="biscof">
+        <renameColumn tableName="account" oldColumnName="created_date" newColumnName="created_date_temp"/>
+        <renameColumn tableName="account" oldColumnName="modified_date" newColumnName="modified_date_temp"/>
+
+        <addColumn tableName="account">
+            <column name="created_date" type="TIMESTAMP WITH TIME ZONE"/>
+        </addColumn>
+        <addColumn tableName="account">
+            <column name="modified_date" type="TIMESTAMP WITH TIME ZONE"/>
+        </addColumn>
+
+        <sql>UPDATE account SET created_date = created_date_temp AT TIME ZONE 'UTC';</sql>
+        <sql>UPDATE account SET modified_date = modified_date_temp AT TIME ZONE 'UTC';</sql>
+
+        <addNotNullConstraint tableName="account" columnName="created_date"/>
+        <addNotNullConstraint tableName="account" columnName="modified_date"/>
+
+        <dropColumn tableName="account" columnName="created_date_temp"/>
+        <dropColumn tableName="account" columnName="modified_date_temp"/>
+    </changeSet>
+
+
+    <changeSet id="2023-10-16-change-time-format-to-timestamp-with-time-zone-2" author="biscof">
+        <renameColumn tableName="typo" oldColumnName="created_date" newColumnName="created_date_temp"/>
+        <renameColumn tableName="typo" oldColumnName="modified_date" newColumnName="modified_date_temp"/>
+
+        <addColumn tableName="typo">
+            <column name="created_date" type="TIMESTAMP WITH TIME ZONE"/>
+        </addColumn>
+        <addColumn tableName="typo">
+            <column name="modified_date" type="TIMESTAMP WITH TIME ZONE"/>
+        </addColumn>
+
+        <sql>UPDATE typo SET created_date = created_date_temp AT TIME ZONE 'UTC';</sql>
+        <sql>UPDATE typo SET modified_date = modified_date_temp AT TIME ZONE 'UTC';</sql>
+
+        <addNotNullConstraint tableName="typo" columnName="created_date"/>
+        <addNotNullConstraint tableName="typo" columnName="modified_date"/>
+
+        <dropColumn tableName="typo" columnName="created_date_temp"/>
+        <dropColumn tableName="typo" columnName="modified_date_temp"/>
+    </changeSet>
+
+
+    <changeSet id="2023-10-16-change-time-format-to-timestamp-with-time-zone-3" author="biscof">
+        <renameColumn tableName="workspace" oldColumnName="created_date" newColumnName="created_date_temp"/>
+        <renameColumn tableName="workspace" oldColumnName="modified_date" newColumnName="modified_date_temp"/>
+
+        <addColumn tableName="workspace">
+            <column name="created_date" type="TIMESTAMP WITH TIME ZONE"/>
+        </addColumn>
+        <addColumn tableName="workspace">
+            <column name="modified_date" type="TIMESTAMP WITH TIME ZONE"/>
+        </addColumn>
+
+        <sql>UPDATE workspace SET created_date = created_date_temp AT TIME ZONE 'UTC';</sql>
+        <sql>UPDATE workspace SET modified_date = modified_date_temp AT TIME ZONE 'UTC';</sql>
+
+        <addNotNullConstraint tableName="workspace" columnName="created_date"/>
+        <addNotNullConstraint tableName="workspace" columnName="modified_date"/>
+
+        <dropColumn tableName="workspace" columnName="created_date_temp"/>
+        <dropColumn tableName="workspace" columnName="modified_date_temp"/>
+    </changeSet>
+
+
+    <changeSet id="2023-10-16-change-time-format-to-timestamp-with-time-zone-4" author="biscof">
+        <renameColumn tableName="workspace_settings" oldColumnName="created_date" newColumnName="created_date_temp"/>
+        <renameColumn tableName="workspace_settings" oldColumnName="modified_date" newColumnName="modified_date_temp"/>
+
+        <addColumn tableName="workspace_settings">
+            <column name="created_date" type="TIMESTAMP WITH TIME ZONE"/>
+        </addColumn>
+        <addColumn tableName="workspace_settings">
+            <column name="modified_date" type="TIMESTAMP WITH TIME ZONE"/>
+        </addColumn>
+
+        <sql>UPDATE workspace_settings SET created_date = created_date_temp AT TIME ZONE 'UTC';</sql>
+        <sql>UPDATE workspace_settings SET modified_date = modified_date_temp AT TIME ZONE 'UTC';</sql>
+
+        <addNotNullConstraint tableName="workspace_settings" columnName="created_date"/>
+        <addNotNullConstraint tableName="workspace_settings" columnName="modified_date"/>
+
+        <dropColumn tableName="workspace_settings" columnName="created_date_temp"/>
+        <dropColumn tableName="workspace_settings" columnName="modified_date_temp"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -21,4 +21,6 @@
              relativeToChangelogFile="true" />
     <include file="changesets/2022/12/2022-12-08-create-workspace-settings-table.xml"
              relativeToChangelogFile="true" />
+    <include file="changesets/2023/10/2023-10-16-change-time-format-to-timestamp-with-time-zone.xml"
+             relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -73,15 +73,15 @@ btn.page-size=Page size
 btn.page-empty-filter=All statuses
 
 text.leave-comment=Leave additional comment:
-text.last-typo-added=Last typo added {0} at {1}
+text.last-typo-added=Last typo added {0} at
 text.number-of-typos=Total number of typos in workspace {0}: {1}
 text.wks-access-token=Workspace API access token
 text.use-header=You shall use header
 
 text.script-descr=Install this script on your website:
 
-text.modified-info=Modified by {0} {1} at {2}
-text.created-info=Created by {0} {1} at {2}
+text.modified-info=Modified by {0} {1} at
+text.created-info=Created by {0} {1} at
 text.created-at=Created at
 text.modified-at=Modified at
 text.reported-by=Reported by

--- a/src/main/resources/messages_ru.properties
+++ b/src/main/resources/messages_ru.properties
@@ -73,13 +73,13 @@ alert.general-error=Во время работы произошла ошибка
 alert.report-success=Сообщение об ошибке успешно отправлено. Спасибо!
 
 text.wks-access-token=Токен доступа для API Пространства
-text.last-typo-added=Последняя опечатка была добавлена {0} в {1}
+text.last-typo-added=Последняя опечатка была добавлена {0} в
 text.number-of-typos=Всего опечаток в пространстве {0}: {1}
 text.leave-comment=Оставить дополнительный комментарий:
 text.use-header=Используйте заголовок
 text.script-descr=Установите этот скрипт на ваш сайт:
-text.modified-info=Изменен пользователем {0} {1} в {2}
-text.created-info=Создан пользователем {0} {1} в {2}
+text.modified-info=Изменен пользователем {0} {1} в
+text.created-info=Создан пользователем {0} {1} в
 text.created-at=Создан
 text.modified-at=Изменен
 text.reported-by=Отправитель

--- a/src/main/resources/static/fragments/time-converter.js
+++ b/src/main/resources/static/fragments/time-converter.js
@@ -1,0 +1,13 @@
+function adjustDateToUserTimeZone(utcDate) {
+  var adjustedTime = new Date(utcDate);
+  return`${adjustedTime.toLocaleTimeString()} ${adjustedTime.toLocaleDateString()}`;
+}
+
+function adjustAllDatesOnPageToUserTimeZone() {
+  document.querySelectorAll('[data-original-date]').forEach(function (element) {
+    var originalTime = element.getAttribute('data-original-date');
+    element.textContent = adjustDateToUserTimeZone(originalTime);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', adjustAllDatesOnPageToUserTimeZone);

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -11,8 +11,10 @@
     <link rel="stylesheet" th:href="@{/webjars/bootstrap/css/bootstrap.min.css}" type="text/css" />
     <!-- Bootstrap Bundle with Popper -->
     <script th:src="@{/webjars/bootstrap/js/bootstrap.bundle.min.js}" type="text/javascript"></script>
-    <!-- Language switcher-->
+    <!-- Language switcher -->
     <script th:src="@{/fragments/lang-switcher.js}" type="text/javascript"></script>
+    <!-- Time converter -->
+    <script th:src="@{/fragments/time-converter.js}" type="text/javascript"></script>
 </head>
 <body>
 </body>

--- a/src/main/resources/templates/fragments/workspace.html
+++ b/src/main/resources/templates/fragments/workspace.html
@@ -13,7 +13,11 @@
     </div>
 </div>
 <div class="col" th:fragment="wksLastTypoDate (lastTypoCreatedDateAgo, lastTypoCreatedDate)">
-    <p class="col-6" th:text="|#{text.last-typo-added(${lastTypoCreatedDateAgo.get()}, ${#temporals.format(lastTypoCreatedDate.get(), 'hh:mm:ss dd-MM-yyyy')})}|"></p>
+    <p class="col-6">
+        <span th:text="|#{text.last-typo-added(${lastTypoCreatedDateAgo.get()})}|"></span>
+        <!-- The text will be overwritten by time-converter.js unless JS is disabled -->
+        <span th:text="${#temporals.format(lastTypoCreatedDate.get(), 'HH:mm:ss dd-MM-yyyy')}" th:data-original-date="${lastTypoCreatedDate.get()}"></span>
+    </p>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/workspace/wks-info.html
+++ b/src/main/resources/templates/workspace/wks-info.html
@@ -33,10 +33,15 @@
                             </form>
                         </div>
                         <div class="card-footer text-muted fst-italic">
-                            <h6 class="card-subtitle m-2"
-                                th:text="|#{text.modified-info(*{modifiedBy}, *{modifiedDateAgo}, *{#temporals.format(modifiedDate, 'hh:mm:ss dd-MM-yyyy')})}|"></h6>
-                            <h6 class="card-subtitle m-2"
-                                th:text="|#{text.created-info(*{createdBy}, *{createdDateAgo}, *{#temporals.format(createdDate, 'hh:mm:ss dd-MM-yyyy')})}|"></h6>
+                            <h6 class="card-subtitle m-2">
+                                <span th:text="|#{text.modified-info(*{modifiedBy}, *{modifiedDateAgo})}|"></span>
+                                <!-- The text will be overwritten by time-converter.js unless JS is disabled -->
+                                <span th:text="*{#temporals.format(modifiedDate, 'HH:mm:ss dd-MM-yyyy')}" th:data-original-date="*{modifiedDate}"></span>
+                            </h6>
+                            <h6 class="card-subtitle m-2">
+                                <span th:text="|#{text.created-info(*{createdBy}, *{createdDateAgo})}|"></span>
+                                <!-- The text will be overwritten by time-converter.js unless JS is disabled -->
+                                <span th:text="*{#temporals.format(createdDate, 'HH:mm:ss dd-MM-yyyy')}" th:data-original-date="*{createdDate}"></span>                            </h6>
                         </div>
                     </div>
                 </div>

--- a/src/main/resources/templates/workspace/wks-typos.html
+++ b/src/main/resources/templates/workspace/wks-typos.html
@@ -190,8 +190,16 @@
                                                     </div>
                                                     <div class="row">
                                                         <div class="col">
-                                                            <p th:text="|#{text.created-at} *{#temporals.format(createdDate, 'dd/MM/yyyy hh:mm:ss')}|"></p>
-                                                            <p th:text="|#{text.modified-at} *{#temporals.format(modifiedDate, 'dd/MM/yyyy hh:mm:ss')}|"></p>
+                                                            <p>
+                                                                <span th:text="|#{text.created-at}|"/>
+                                                                <!-- The text will be overwritten by time-converter.js unless JS is disabled -->
+                                                                <span th:text="*{#temporals.format(createdDate, 'dd/MM/yyyy HH:mm:ss')}" th:data-original-date="*{createdDate}"/>
+                                                            </p>
+                                                            <p>
+                                                                <span th:text="|#{text.modified-at}|"/>
+                                                                <!-- The text will be overwritten by time-converter.js unless JS is disabled -->
+                                                                <span th:text="*{#temporals.format(modifiedDate, 'dd/MM/yyyy HH:mm:ss')}" th:data-original-date="*{modifiedDate}"/>
+                                                            </p>
                                                             <hr>
                                                             <p class="fst-italic"
                                                                th:text="|#{text.reported-by} *{reporterName}: *{reporterComment}|"></p>

--- a/src/test/java/io/hexlet/typoreporter/test/factory/EntitiesFactory.java
+++ b/src/test/java/io/hexlet/typoreporter/test/factory/EntitiesFactory.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
-import static java.time.LocalDateTime.now;
+import static java.time.Instant.now;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 public class EntitiesFactory {

--- a/src/test/java/io/hexlet/typoreporter/web/WorkspaceApiIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/WorkspaceApiIT.java
@@ -30,7 +30,7 @@ import static com.github.database.rider.core.api.configuration.Orthography.LOWER
 import static io.hexlet.typoreporter.test.Constraints.POSTGRES_IMAGE;
 import static io.hexlet.typoreporter.test.factory.EntitiesFactory.WORKSPACE_101_ID;
 import static io.hexlet.typoreporter.test.factory.EntitiesFactory.WORKSPACE_101_TOKEN;
-import static java.time.LocalDateTime.now;
+import static java.time.Instant.now;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;

--- a/src/test/java/io/hexlet/typoreporter/web/WorkspaceControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/WorkspaceControllerIT.java
@@ -32,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.*;
 import org.junit.jupiter.api.Disabled;
 import static com.github.database.rider.core.api.configuration.Orthography.LOWERCASE;
@@ -207,7 +207,7 @@ class WorkspaceControllerIT {
     void putWorkspaceUpdateIsSuccessful(final String wksName, final String username) throws Exception {
         Workspace workspace = repository.getWorkspaceByName(wksName).orElse(null);
         String newWksName = "createWksName01";
-        LocalDateTime previosModifiedDate = workspace.getModifiedDate();
+        Instant previosModifiedDate = workspace.getModifiedDate();
 
         mockMvc.perform(put("/workspace/{wksName}/update", wksName)
                 .param("name", newWksName)
@@ -217,7 +217,7 @@ class WorkspaceControllerIT {
                 .with(csrf()))
             .andExpect(redirectedUrl("/workspace/" + newWksName));
 
-        LocalDateTime newModifiedDate = repository.getWorkspaceByName(newWksName).orElse(null).getModifiedDate();
+        Instant newModifiedDate = repository.getWorkspaceByName(newWksName).orElse(null).getModifiedDate();
         assertThat(previosModifiedDate).isNotEqualTo(newModifiedDate);
     }
 
@@ -228,7 +228,7 @@ class WorkspaceControllerIT {
         String wksDescription = "Wks description";
         String wksUrl = "https://other.com";
 
-        LocalDateTime previousModifiedDate = repository.getWorkspaceByName(wksName).orElse(null).getModifiedDate();
+        Instant previousModifiedDate = repository.getWorkspaceByName(wksName).orElse(null).getModifiedDate();
 
         var createWks = new CreateWorkspace(newWksName, wksDescription, wksUrl);
         final var wksToCreate = requireNonNull(workspaceMapper.toWorkspace(createWks));
@@ -246,7 +246,7 @@ class WorkspaceControllerIT {
                 .with(csrf()))
             .andExpect(model().attributeExists("createWorkspace"));
 
-        LocalDateTime newModifiedDate = repository.getWorkspaceByName(wksName).orElse(null).getModifiedDate();
+        Instant newModifiedDate = repository.getWorkspaceByName(wksName).orElse(null).getModifiedDate();
         assertThat(previousModifiedDate).isEqualTo(newModifiedDate);
     }
 
@@ -257,7 +257,7 @@ class WorkspaceControllerIT {
         String wksDescription = "Wks description";
         String newWksUrl = "https://other.com";
 
-        LocalDateTime previousModifiedDate = repository.getWorkspaceByName(wksName).orElse(null).getModifiedDate();
+        Instant previousModifiedDate = repository.getWorkspaceByName(wksName).orElse(null).getModifiedDate();
 
         var createWks = new CreateWorkspace(newWksName, wksDescription, newWksUrl);
         final var wksToCreate = requireNonNull(workspaceMapper.toWorkspace(createWks));
@@ -276,7 +276,7 @@ class WorkspaceControllerIT {
                 .with(csrf()))
             .andExpect(model().attributeExists("createWorkspace"));
 
-        LocalDateTime newModifiedDate = repository.getWorkspaceByName(wksName).orElse(null).getModifiedDate();
+        Instant newModifiedDate = repository.getWorkspaceByName(wksName).orElse(null).getModifiedDate();
         assertThat(previousModifiedDate).isEqualTo(newModifiedDate);
     }
 


### PR DESCRIPTION
Fixes #167 

1. Изменил тип даты/времени в коде с `LocalDateTime` на `Instant`, чтобы сделать привязку к UTC. Добавил миграцию, которая учитывает эти изменения. Все предыдущие записи дат приводятся в формат `TIMESTAMP WITH TIME ZONE` с часовым поясом UTC+00. Так как определить исходный часовой пояс этих записей невозможно, их точность снизится, зато новые записи будут точнее.

2. Дата отображается пользователям в их часовом поясе. Для этого добавил скрипт `time-converter.js` и поправил шаблоны. Если JS в браузере отключен, дата отобразится в формате UTC+00.

3. Сделал локализацию сообщений об относительном времени создания/изменения (`PrettyTime`).

4. Починил метод в `TypoRepository`, который возвращает последнюю добавленную опечатку (до этого он возвращал опечатку, добавленную первой).

[Демо](https://hexlet-correction-issue-167.onrender.com/)