### PR TITLE
Авторизация по почте вместо имени пользователя

### DIFF
--- a/src/main/java/io/hexlet/typoreporter/config/SecurityConfig.java
+++ b/src/main/java/io/hexlet/typoreporter/config/SecurityConfig.java
@@ -83,6 +83,9 @@ public class SecurityConfig {
             )
             .formLogin(login -> login
                 .loginPage("/login")
+                //my add
+                .usernameParameter("email")
+                //my add end
                 .defaultSuccessUrl("/workspaces")
                 .permitAll()
             )

--- a/src/main/java/io/hexlet/typoreporter/config/SecurityConfig.java
+++ b/src/main/java/io/hexlet/typoreporter/config/SecurityConfig.java
@@ -83,9 +83,7 @@ public class SecurityConfig {
             )
             .formLogin(login -> login
                 .loginPage("/login")
-                //my add
                 .usernameParameter("email")
-                //my add end
                 .defaultSuccessUrl("/workspaces")
                 .permitAll()
             )

--- a/src/main/java/io/hexlet/typoreporter/repository/AccountRepository.java
+++ b/src/main/java/io/hexlet/typoreporter/repository/AccountRepository.java
@@ -11,8 +11,6 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
     Optional<Account> findAccountByEmail(String email);
 
-    Optional<Account> findAccountByUsername(String username);
-
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
 }

--- a/src/main/java/io/hexlet/typoreporter/repository/WorkspaceRoleRepository.java
+++ b/src/main/java/io/hexlet/typoreporter/repository/WorkspaceRoleRepository.java
@@ -14,8 +14,12 @@ public interface WorkspaceRoleRepository extends JpaRepository<WorkspaceRole, Lo
     @EntityGraph(attributePaths = {"account", "workspace"})
     List<WorkspaceRole> getWorkspaceRolesByAccountId(Long accountId);
 
+    //my add
+//    @EntityGraph(attributePaths = {"account", "workspace"})
+//    List<WorkspaceRole> getWorkspaceRolesByAccountUsername(String username);
     @EntityGraph(attributePaths = {"account", "workspace"})
-    List<WorkspaceRole> getWorkspaceRolesByAccountUsername(String username);
+    List<WorkspaceRole> getWorkspaceRolesByAccountEmail(String email);
+    //my add end
 
     @EntityGraph(attributePaths = {"account", "workspace"})
     List<WorkspaceRole> getWorkspaceRolesByWorkspaceId(Long workspaceId);

--- a/src/main/java/io/hexlet/typoreporter/repository/WorkspaceRoleRepository.java
+++ b/src/main/java/io/hexlet/typoreporter/repository/WorkspaceRoleRepository.java
@@ -14,12 +14,8 @@ public interface WorkspaceRoleRepository extends JpaRepository<WorkspaceRole, Lo
     @EntityGraph(attributePaths = {"account", "workspace"})
     List<WorkspaceRole> getWorkspaceRolesByAccountId(Long accountId);
 
-    //my add
-//    @EntityGraph(attributePaths = {"account", "workspace"})
-//    List<WorkspaceRole> getWorkspaceRolesByAccountUsername(String username);
     @EntityGraph(attributePaths = {"account", "workspace"})
     List<WorkspaceRole> getWorkspaceRolesByAccountEmail(String email);
-    //my add end
 
     @EntityGraph(attributePaths = {"account", "workspace"})
     List<WorkspaceRole> getWorkspaceRolesByWorkspaceId(Long workspaceId);

--- a/src/main/java/io/hexlet/typoreporter/security/service/AccountDetailService.java
+++ b/src/main/java/io/hexlet/typoreporter/security/service/AccountDetailService.java
@@ -16,17 +16,13 @@ public class AccountDetailService implements UserDetailsService {
     private final AccountRepository accountRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        final String normalizedUsername = TextUtils.toLowerCaseData(username);
-        //my add
-//        return accountRepository.findAccountByUsername(normalizedUsername)
-//            .map(acc -> User.withUsername(acc.getUsername())
-        return accountRepository.findAccountByEmail(normalizedUsername)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        final String normalizedEmail = TextUtils.toLowerCaseData(email);
+        return accountRepository.findAccountByEmail(normalizedEmail)
             .map(acc -> User.withUsername(acc.getEmail())
-        //my add end
                 .password(acc.getPassword())
                 .authorities("USER")
                 .build())
-            .orElseThrow(() -> new UsernameNotFoundException("Account with name='" + username + "' not found"));
+            .orElseThrow(() -> new UsernameNotFoundException("Account with email='" + email + "' not found"));
     }
 }

--- a/src/main/java/io/hexlet/typoreporter/security/service/AccountDetailService.java
+++ b/src/main/java/io/hexlet/typoreporter/security/service/AccountDetailService.java
@@ -18,8 +18,12 @@ public class AccountDetailService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         final String normalizedUsername = TextUtils.toLowerCaseData(username);
-        return accountRepository.findAccountByUsername(normalizedUsername)
-            .map(acc -> User.withUsername(acc.getUsername())
+        //my add
+//        return accountRepository.findAccountByUsername(normalizedUsername)
+//            .map(acc -> User.withUsername(acc.getUsername())
+        return accountRepository.findAccountByEmail(normalizedUsername)
+            .map(acc -> User.withUsername(acc.getEmail())
+        //my add end
                 .password(acc.getPassword())
                 .authorities("USER")
                 .build())

--- a/src/main/java/io/hexlet/typoreporter/service/AccountService.java
+++ b/src/main/java/io/hexlet/typoreporter/service/AccountService.java
@@ -73,7 +73,11 @@ public class AccountService implements SignupAccountUseCase, QueryAccount {
 
     @Transactional(readOnly = true)
     public InfoAccount getInfoAccount(final String name) {
-        return accountRepository.findAccountByUsername(name)
+        //my add
+//        return accountRepository.findAccountByUsername(name)
+        return accountRepository.findAccountByEmail(name)
+        //my add end
+
             .map(accountMapper::toInfoAccount)
             .orElseThrow(() -> new AccountNotFoundException(name));
     }
@@ -102,6 +106,14 @@ public class AccountService implements SignupAccountUseCase, QueryAccount {
         return accountRepository.findAccountByUsername(userName)
             .orElseThrow(() -> new AccountNotFoundException(userName));
     }
+
+    //my add
+    @Transactional(readOnly = true)
+    public Account findByEmail(String email) {
+        return accountRepository.findAccountByEmail(email)
+            .orElseThrow(() -> new AccountNotFoundException(email));
+    }
+    //my add end
 
     public Account updateProfile(final UpdateProfile updateProfile, final String name) {
         final var sourceAccount = accountRepository.findAccountByUsername(name)

--- a/src/main/java/io/hexlet/typoreporter/service/AccountService.java
+++ b/src/main/java/io/hexlet/typoreporter/service/AccountService.java
@@ -71,52 +71,26 @@ public class AccountService implements SignupAccountUseCase, QueryAccount {
         return accountMapper.toInfoAccount(accToSave);
     }
 
-    //my end
-//    @Transactional(readOnly = true)
-//    public InfoAccount getInfoAccount(final String name) {
-//        return accountRepository.findAccountByUsername(name)
-//
-//            .map(accountMapper::toInfoAccount)
-//            .orElseThrow(() -> new AccountNotFoundException(name));
-//    }
     @Transactional(readOnly = true)
     public InfoAccount getInfoAccount(final String email) {
         return accountRepository.findAccountByEmail(email)
             .map(accountMapper::toInfoAccount)
             .orElseThrow(() -> new AccountNotFoundException(email));
     }
-    //my end
 
-    //my add
-//    @Transactional(readOnly = true)
-//    public List<WorkspaceRoleInfo> getWorkspacesInfoListByUsername(final String username) {
-//        return workspaceRoleRepository.getWorkspaceRolesByAccountUsername(username).stream()
-//            .map(workspaceRoleMapper::toWorkspaceRoleInfo)
-//            .toList();
-//    }
     @Transactional(readOnly = true)
     public List<WorkspaceRoleInfo> getWorkspacesInfoListByEmail(final String email) {
         return workspaceRoleRepository.getWorkspaceRolesByAccountEmail(email).stream()
             .map(workspaceRoleMapper::toWorkspaceRoleInfo)
             .toList();
     }
-    //my add end
 
-
-    //my add
-//    @Transactional(readOnly = true)
-//    public UpdateProfile getUpdateProfile(final String name) {
-//        return accountRepository.findAccountByUsername(name)
-//            .map(accountMapper::toUpdateProfile)
-//            .orElseThrow(() -> new AccountNotFoundException(name));
-//    }
     @Transactional(readOnly = true)
     public UpdateProfile getUpdateProfile(final String email) {
         return accountRepository.findAccountByEmail(email)
             .map(accountMapper::toUpdateProfile)
             .orElseThrow(() -> new AccountNotFoundException(email));
     }
-    //my add end
 
     @Transactional(readOnly = true)
     public List<Account> findAll() {
@@ -124,39 +98,11 @@ public class AccountService implements SignupAccountUseCase, QueryAccount {
     }
 
     @Transactional(readOnly = true)
-    public Account findByUsername(String userName) {
-        return accountRepository.findAccountByUsername(userName)
-            .orElseThrow(() -> new AccountNotFoundException(userName));
-    }
-
-    //my add
-    @Transactional(readOnly = true)
     public Account findByEmail(String email) {
         return accountRepository.findAccountByEmail(email)
             .orElseThrow(() -> new AccountNotFoundException(email));
     }
-    //my add end
 
-    //my add
-//    public Account updateProfile(final UpdateProfile updateProfile, final String name) {
-//        final var sourceAccount = accountRepository.findAccountByUsername(name)
-//            .orElseThrow(() -> new AccountNotFoundException(name));
-//        final String sourceUserName = sourceAccount.getUsername();
-//        final String normalizedUserName = TextUtils.toLowerCaseData(updateProfile.getUsername());
-//        final String normalizedEmail = TextUtils.toLowerCaseData(updateProfile.getEmail());
-//        if (!sourceUserName.equals(normalizedUserName) && existsByUsername(normalizedUserName)) {
-//            throw new AccountAlreadyExistException("username", normalizedUserName);
-//        }
-//        final String sourceEmail = sourceAccount.getEmail();
-//        if (!sourceEmail.equals(normalizedEmail) && existsByEmail(normalizedEmail)) {
-//            throw new AccountAlreadyExistException("email", normalizedEmail);
-//        }
-//        Account updAccount = accountMapper.toAccount(updateProfile, sourceAccount);
-//        updAccount.setUsername(normalizedUserName);
-//        updAccount.setEmail(normalizedEmail);
-//        accountRepository.save(updAccount);
-//        return updAccount;
-//    }
     public Account updateProfile(final UpdateProfile updateProfile, final String email) {
         final var sourceAccount = accountRepository.findAccountByEmail(email)
             .orElseThrow(() -> new AccountNotFoundException(email));
@@ -176,24 +122,7 @@ public class AccountService implements SignupAccountUseCase, QueryAccount {
         accountRepository.save(updAccount);
         return updAccount;
     }
-    //my add end
 
-    //my add
-//    public Account updatePassword(final UpdatePassword updatePassword, final String name) {
-//        final var sourceAccount = accountRepository.findAccountByUsername(name)
-//            .orElseThrow(() -> new AccountNotFoundException(name));
-//        final String password = sourceAccount.getPassword();
-//        if (!passwordEncoder.matches(updatePassword.getOldPassword(), password)) {
-//            throw new OldPasswordWrongException();
-//        }
-//        if (passwordEncoder.matches(updatePassword.getNewPassword(), password)) {
-//            throw new NewPasswordTheSameException();
-//        }
-//        final String newPassword = passwordEncoder.encode(updatePassword.getNewPassword());
-//        sourceAccount.setPassword(newPassword);
-//        accountRepository.save(sourceAccount);
-//        return sourceAccount;
-//    }
     public Account updatePassword(final UpdatePassword updatePassword, final String email) {
         final var sourceAccount = accountRepository.findAccountByEmail(email)
             .orElseThrow(() -> new AccountNotFoundException(email));
@@ -209,5 +138,4 @@ public class AccountService implements SignupAccountUseCase, QueryAccount {
         accountRepository.save(sourceAccount);
         return sourceAccount;
     }
-    //my add end
 }

--- a/src/main/java/io/hexlet/typoreporter/service/AccountService.java
+++ b/src/main/java/io/hexlet/typoreporter/service/AccountService.java
@@ -71,23 +71,37 @@ public class AccountService implements SignupAccountUseCase, QueryAccount {
         return accountMapper.toInfoAccount(accToSave);
     }
 
-    @Transactional(readOnly = true)
-    public InfoAccount getInfoAccount(final String name) {
-        //my add
+    //my end
+//    @Transactional(readOnly = true)
+//    public InfoAccount getInfoAccount(final String name) {
 //        return accountRepository.findAccountByUsername(name)
-        return accountRepository.findAccountByEmail(name)
-        //my add end
-
-            .map(accountMapper::toInfoAccount)
-            .orElseThrow(() -> new AccountNotFoundException(name));
-    }
-
+//
+//            .map(accountMapper::toInfoAccount)
+//            .orElseThrow(() -> new AccountNotFoundException(name));
+//    }
     @Transactional(readOnly = true)
-    public List<WorkspaceRoleInfo> getWorkspacesInfoListByUsername(final String username) {
-        return workspaceRoleRepository.getWorkspaceRolesByAccountUsername(username).stream()
+    public InfoAccount getInfoAccount(final String email) {
+        return accountRepository.findAccountByEmail(email)
+            .map(accountMapper::toInfoAccount)
+            .orElseThrow(() -> new AccountNotFoundException(email));
+    }
+    //my end
+
+    //my add
+//    @Transactional(readOnly = true)
+//    public List<WorkspaceRoleInfo> getWorkspacesInfoListByUsername(final String username) {
+//        return workspaceRoleRepository.getWorkspaceRolesByAccountUsername(username).stream()
+//            .map(workspaceRoleMapper::toWorkspaceRoleInfo)
+//            .toList();
+//    }
+    @Transactional(readOnly = true)
+    public List<WorkspaceRoleInfo> getWorkspacesInfoListByEmail(final String email) {
+        return workspaceRoleRepository.getWorkspaceRolesByAccountEmail(email).stream()
             .map(workspaceRoleMapper::toWorkspaceRoleInfo)
             .toList();
     }
+    //my add end
+
 
     //my add
 //    @Transactional(readOnly = true)

--- a/src/main/java/io/hexlet/typoreporter/service/AccountService.java
+++ b/src/main/java/io/hexlet/typoreporter/service/AccountService.java
@@ -89,12 +89,20 @@ public class AccountService implements SignupAccountUseCase, QueryAccount {
             .toList();
     }
 
+    //my add
+//    @Transactional(readOnly = true)
+//    public UpdateProfile getUpdateProfile(final String name) {
+//        return accountRepository.findAccountByUsername(name)
+//            .map(accountMapper::toUpdateProfile)
+//            .orElseThrow(() -> new AccountNotFoundException(name));
+//    }
     @Transactional(readOnly = true)
-    public UpdateProfile getUpdateProfile(final String name) {
-        return accountRepository.findAccountByUsername(name)
+    public UpdateProfile getUpdateProfile(final String email) {
+        return accountRepository.findAccountByEmail(email)
             .map(accountMapper::toUpdateProfile)
-            .orElseThrow(() -> new AccountNotFoundException(name));
+            .orElseThrow(() -> new AccountNotFoundException(email));
     }
+    //my add end
 
     @Transactional(readOnly = true)
     public List<Account> findAll() {
@@ -115,9 +123,29 @@ public class AccountService implements SignupAccountUseCase, QueryAccount {
     }
     //my add end
 
-    public Account updateProfile(final UpdateProfile updateProfile, final String name) {
-        final var sourceAccount = accountRepository.findAccountByUsername(name)
-            .orElseThrow(() -> new AccountNotFoundException(name));
+    //my add
+//    public Account updateProfile(final UpdateProfile updateProfile, final String name) {
+//        final var sourceAccount = accountRepository.findAccountByUsername(name)
+//            .orElseThrow(() -> new AccountNotFoundException(name));
+//        final String sourceUserName = sourceAccount.getUsername();
+//        final String normalizedUserName = TextUtils.toLowerCaseData(updateProfile.getUsername());
+//        final String normalizedEmail = TextUtils.toLowerCaseData(updateProfile.getEmail());
+//        if (!sourceUserName.equals(normalizedUserName) && existsByUsername(normalizedUserName)) {
+//            throw new AccountAlreadyExistException("username", normalizedUserName);
+//        }
+//        final String sourceEmail = sourceAccount.getEmail();
+//        if (!sourceEmail.equals(normalizedEmail) && existsByEmail(normalizedEmail)) {
+//            throw new AccountAlreadyExistException("email", normalizedEmail);
+//        }
+//        Account updAccount = accountMapper.toAccount(updateProfile, sourceAccount);
+//        updAccount.setUsername(normalizedUserName);
+//        updAccount.setEmail(normalizedEmail);
+//        accountRepository.save(updAccount);
+//        return updAccount;
+//    }
+    public Account updateProfile(final UpdateProfile updateProfile, final String email) {
+        final var sourceAccount = accountRepository.findAccountByEmail(email)
+            .orElseThrow(() -> new AccountNotFoundException(email));
         final String sourceUserName = sourceAccount.getUsername();
         final String normalizedUserName = TextUtils.toLowerCaseData(updateProfile.getUsername());
         final String normalizedEmail = TextUtils.toLowerCaseData(updateProfile.getEmail());
@@ -134,10 +162,27 @@ public class AccountService implements SignupAccountUseCase, QueryAccount {
         accountRepository.save(updAccount);
         return updAccount;
     }
+    //my add end
 
-    public Account updatePassword(final UpdatePassword updatePassword, final String name) {
-        final var sourceAccount = accountRepository.findAccountByUsername(name)
-            .orElseThrow(() -> new AccountNotFoundException(name));
+    //my add
+//    public Account updatePassword(final UpdatePassword updatePassword, final String name) {
+//        final var sourceAccount = accountRepository.findAccountByUsername(name)
+//            .orElseThrow(() -> new AccountNotFoundException(name));
+//        final String password = sourceAccount.getPassword();
+//        if (!passwordEncoder.matches(updatePassword.getOldPassword(), password)) {
+//            throw new OldPasswordWrongException();
+//        }
+//        if (passwordEncoder.matches(updatePassword.getNewPassword(), password)) {
+//            throw new NewPasswordTheSameException();
+//        }
+//        final String newPassword = passwordEncoder.encode(updatePassword.getNewPassword());
+//        sourceAccount.setPassword(newPassword);
+//        accountRepository.save(sourceAccount);
+//        return sourceAccount;
+//    }
+    public Account updatePassword(final UpdatePassword updatePassword, final String email) {
+        final var sourceAccount = accountRepository.findAccountByEmail(email)
+            .orElseThrow(() -> new AccountNotFoundException(email));
         final String password = sourceAccount.getPassword();
         if (!passwordEncoder.matches(updatePassword.getOldPassword(), password)) {
             throw new OldPasswordWrongException();
@@ -150,4 +195,5 @@ public class AccountService implements SignupAccountUseCase, QueryAccount {
         accountRepository.save(sourceAccount);
         return sourceAccount;
     }
+    //my add end
 }

--- a/src/main/java/io/hexlet/typoreporter/service/WorkspaceService.java
+++ b/src/main/java/io/hexlet/typoreporter/service/WorkspaceService.java
@@ -59,27 +59,6 @@ public class WorkspaceService {
         return workspaceRepository.existsWorkspaceById(wksId);
     }
 
-    //my add
-//    @Transactional
-//    public WorkspaceInfo createWorkspace(final CreateWorkspace createWks, final String userName) {
-//        if (workspaceRepository.existsWorkspaceByUrl(createWks.url())) {
-//            throw new WorkspaceAlreadyExistException("url", createWks.url());
-//        }
-//
-//        final var wksToCreate = requireNonNull(workspaceMapper.toWorkspace(createWks));
-//        final var wksSettings = new WorkspaceSettings();
-//        wksSettings.setApiAccessToken(UUID.randomUUID());
-//        wksSettings.setWorkspace(wksToCreate);
-//
-//        Account account = accountRepository.findAccountByUsername(userName).orElseThrow();
-//
-//        final var workspaceRoleId = new WorkspaceRoleId(wksToCreate.getId(), account.getId());
-//        final var workspaceRole = new WorkspaceRole(workspaceRoleId, AccountRole.ROLE_ADMIN, wksToCreate, account);
-//        wksToCreate.addWorkspaceRole(workspaceRole);
-//
-//        settingsRepository.save(wksSettings);
-//        return workspaceMapper.toWorkspaceInfo(wksToCreate);
-//    }
     @Transactional
     public WorkspaceInfo createWorkspace(final CreateWorkspace createWks, final String email) {
         if (workspaceRepository.existsWorkspaceByUrl(createWks.url())) {
@@ -100,7 +79,6 @@ public class WorkspaceService {
         settingsRepository.save(wksSettings);
         return workspaceMapper.toWorkspaceInfo(wksToCreate);
     }
-    //my add end
 
     @Transactional
     public WorkspaceInfo updateWorkspace(final CreateWorkspace updateWks, final Long wksId) {
@@ -126,15 +104,6 @@ public class WorkspaceService {
         return workspaceRepository.getWorkspaceById(wksId);
     }
 
-    //my add
-//    @Transactional(readOnly = true)
-//    public List<WorkspaceInfo> getAllWorkspacesInfoByUsername(String username) {
-//        final var accountOptional = accountRepository.findAccountByUsername(username);
-//        return accountOptional.map(account -> account.getWorkspaceRoles().stream()
-//            .map(WorkspaceRole::getWorkspace)
-//            .map(workspaceMapper::toWorkspaceInfo)
-//            .toList()).orElseGet(ArrayList::new);
-//    }
     @Transactional(readOnly = true)
     public List<WorkspaceInfo> getAllWorkspacesInfoByEmail(String email) {
         final var accountOptional = accountRepository.findAccountByEmail(email);
@@ -143,17 +112,7 @@ public class WorkspaceService {
             .map(workspaceMapper::toWorkspaceInfo)
             .toList()).orElseGet(ArrayList::new);
     }
-    //my add end
 
-    //my add
-//    @Transactional
-//    public boolean isUserRelatedToWorkspace(Long wksId, String username) {
-//        final var accountOptional = accountRepository.findAccountByUsername(username);
-//        return accountOptional.map(account -> account.getWorkspaceRoles().stream()
-//                .map(WorkspaceRole::getWorkspace)
-//                .anyMatch(wks -> wks.getId().equals(wksId)))
-//            .orElse(false);
-//    }
     @Transactional
     public boolean isUserRelatedToWorkspace(Long wksId, String email) {
         final var accountOptional = accountRepository.findAccountByEmail(email);
@@ -162,21 +121,7 @@ public class WorkspaceService {
                 .anyMatch(wks -> wks.getId().equals(wksId)))
             .orElse(false);
     }
-    //my add end
 
-    //my add
-//    @Transactional(readOnly = true)
-//    public boolean isAdminRoleUserInWorkspace(Long wksId, String username) {
-//        final var account = accountRepository.findAccountByUsername(username).
-//            orElseThrow(() -> new AccountNotFoundException(username));
-//        final var workspace = workspaceRepository.getWorkspaceById(wksId).
-//            orElseThrow(() -> new WorkspaceNotFoundException(wksId));
-//        final var workSpaceRoleOptional = workspaceRoleRepository.getWorkspaceRoleByAccountIdAndWorkspaceId(
-//            account.getId(),
-//            workspace.getId()
-//        );
-//        return workSpaceRoleOptional.filter(workspaceRole -> workspaceRole.getRole() == AccountRole.ROLE_ADMIN).isPresent();
-//    }
     @Transactional(readOnly = true)
     public boolean isAdminRoleUserInWorkspace(Long wksId, String email) {
         final var account = accountRepository.findAccountByEmail(email).
@@ -189,5 +134,4 @@ public class WorkspaceService {
         );
         return workSpaceRoleOptional.filter(workspaceRole -> workspaceRole.getRole() == AccountRole.ROLE_ADMIN).isPresent();
     }
-    //my add end
 }

--- a/src/main/java/io/hexlet/typoreporter/service/WorkspaceService.java
+++ b/src/main/java/io/hexlet/typoreporter/service/WorkspaceService.java
@@ -59,8 +59,29 @@ public class WorkspaceService {
         return workspaceRepository.existsWorkspaceById(wksId);
     }
 
+    //my add
+//    @Transactional
+//    public WorkspaceInfo createWorkspace(final CreateWorkspace createWks, final String userName) {
+//        if (workspaceRepository.existsWorkspaceByUrl(createWks.url())) {
+//            throw new WorkspaceAlreadyExistException("url", createWks.url());
+//        }
+//
+//        final var wksToCreate = requireNonNull(workspaceMapper.toWorkspace(createWks));
+//        final var wksSettings = new WorkspaceSettings();
+//        wksSettings.setApiAccessToken(UUID.randomUUID());
+//        wksSettings.setWorkspace(wksToCreate);
+//
+//        Account account = accountRepository.findAccountByUsername(userName).orElseThrow();
+//
+//        final var workspaceRoleId = new WorkspaceRoleId(wksToCreate.getId(), account.getId());
+//        final var workspaceRole = new WorkspaceRole(workspaceRoleId, AccountRole.ROLE_ADMIN, wksToCreate, account);
+//        wksToCreate.addWorkspaceRole(workspaceRole);
+//
+//        settingsRepository.save(wksSettings);
+//        return workspaceMapper.toWorkspaceInfo(wksToCreate);
+//    }
     @Transactional
-    public WorkspaceInfo createWorkspace(final CreateWorkspace createWks, final String userName) {
+    public WorkspaceInfo createWorkspace(final CreateWorkspace createWks, final String email) {
         if (workspaceRepository.existsWorkspaceByUrl(createWks.url())) {
             throw new WorkspaceAlreadyExistException("url", createWks.url());
         }
@@ -70,7 +91,7 @@ public class WorkspaceService {
         wksSettings.setApiAccessToken(UUID.randomUUID());
         wksSettings.setWorkspace(wksToCreate);
 
-        Account account = accountRepository.findAccountByUsername(userName).orElseThrow();
+        Account account = accountRepository.findAccountByEmail(email).orElseThrow();
 
         final var workspaceRoleId = new WorkspaceRoleId(wksToCreate.getId(), account.getId());
         final var workspaceRole = new WorkspaceRole(workspaceRoleId, AccountRole.ROLE_ADMIN, wksToCreate, account);
@@ -79,6 +100,7 @@ public class WorkspaceService {
         settingsRepository.save(wksSettings);
         return workspaceMapper.toWorkspaceInfo(wksToCreate);
     }
+    //my add end
 
     @Transactional
     public WorkspaceInfo updateWorkspace(final CreateWorkspace updateWks, final Long wksId) {
@@ -104,28 +126,61 @@ public class WorkspaceService {
         return workspaceRepository.getWorkspaceById(wksId);
     }
 
+    //my add
+//    @Transactional(readOnly = true)
+//    public List<WorkspaceInfo> getAllWorkspacesInfoByUsername(String username) {
+//        final var accountOptional = accountRepository.findAccountByUsername(username);
+//        return accountOptional.map(account -> account.getWorkspaceRoles().stream()
+//            .map(WorkspaceRole::getWorkspace)
+//            .map(workspaceMapper::toWorkspaceInfo)
+//            .toList()).orElseGet(ArrayList::new);
+//    }
     @Transactional(readOnly = true)
-    public List<WorkspaceInfo> getAllWorkspacesInfoByUsername(String username) {
-        final var accountOptional = accountRepository.findAccountByUsername(username);
+    public List<WorkspaceInfo> getAllWorkspacesInfoByEmail(String email) {
+        final var accountOptional = accountRepository.findAccountByEmail(email);
         return accountOptional.map(account -> account.getWorkspaceRoles().stream()
             .map(WorkspaceRole::getWorkspace)
             .map(workspaceMapper::toWorkspaceInfo)
             .toList()).orElseGet(ArrayList::new);
     }
+    //my add end
 
+    //my add
+//    @Transactional
+//    public boolean isUserRelatedToWorkspace(Long wksId, String username) {
+//        final var accountOptional = accountRepository.findAccountByUsername(username);
+//        return accountOptional.map(account -> account.getWorkspaceRoles().stream()
+//                .map(WorkspaceRole::getWorkspace)
+//                .anyMatch(wks -> wks.getId().equals(wksId)))
+//            .orElse(false);
+//    }
     @Transactional
-    public boolean isUserRelatedToWorkspace(Long wksId, String username) {
-        final var accountOptional = accountRepository.findAccountByUsername(username);
+    public boolean isUserRelatedToWorkspace(Long wksId, String email) {
+        final var accountOptional = accountRepository.findAccountByEmail(email);
         return accountOptional.map(account -> account.getWorkspaceRoles().stream()
                 .map(WorkspaceRole::getWorkspace)
                 .anyMatch(wks -> wks.getId().equals(wksId)))
             .orElse(false);
     }
+    //my add end
 
+    //my add
+//    @Transactional(readOnly = true)
+//    public boolean isAdminRoleUserInWorkspace(Long wksId, String username) {
+//        final var account = accountRepository.findAccountByUsername(username).
+//            orElseThrow(() -> new AccountNotFoundException(username));
+//        final var workspace = workspaceRepository.getWorkspaceById(wksId).
+//            orElseThrow(() -> new WorkspaceNotFoundException(wksId));
+//        final var workSpaceRoleOptional = workspaceRoleRepository.getWorkspaceRoleByAccountIdAndWorkspaceId(
+//            account.getId(),
+//            workspace.getId()
+//        );
+//        return workSpaceRoleOptional.filter(workspaceRole -> workspaceRole.getRole() == AccountRole.ROLE_ADMIN).isPresent();
+//    }
     @Transactional(readOnly = true)
-    public boolean isAdminRoleUserInWorkspace(Long wksId, String username) {
-        final var account = accountRepository.findAccountByUsername(username).
-            orElseThrow(() -> new AccountNotFoundException(username));
+    public boolean isAdminRoleUserInWorkspace(Long wksId, String email) {
+        final var account = accountRepository.findAccountByEmail(email).
+            orElseThrow(() -> new AccountNotFoundException(email));
         final var workspace = workspaceRepository.getWorkspaceById(wksId).
             orElseThrow(() -> new WorkspaceNotFoundException(wksId));
         final var workSpaceRoleOptional = workspaceRoleRepository.getWorkspaceRoleByAccountIdAndWorkspaceId(
@@ -134,4 +189,5 @@ public class WorkspaceService {
         );
         return workSpaceRoleOptional.filter(workspaceRole -> workspaceRole.getRole() == AccountRole.ROLE_ADMIN).isPresent();
     }
+    //my add end
 }

--- a/src/main/java/io/hexlet/typoreporter/service/dto/AbstractFieldMatchValidator.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/AbstractFieldMatchValidator.java
@@ -4,31 +4,24 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import org.springframework.beans.PropertyAccessorFactory;
 
-import java.util.Objects;
+import java.lang.annotation.Annotation;
 
-import static java.text.MessageFormat.format;
+import static java.lang.String.format;
 
-public class FieldMatchValidator implements ConstraintValidator<FieldMatch, Object> {
-
+public abstract class AbstractFieldMatchValidator<T extends Annotation> implements ConstraintValidator<T, Object> {
     protected String firstFieldName;
-
     protected String secondFieldName;
-
     protected String message;
 
-    @Override
-    public void initialize(final FieldMatch constraintAnnotation) {
-        firstFieldName = constraintAnnotation.first();
-        secondFieldName = constraintAnnotation.second();
-        message = constraintAnnotation.message();
-    }
+    protected abstract boolean areFieldsValid(Object firstField, Object secondField);
 
     @Override
     public boolean isValid(final Object object, final ConstraintValidatorContext context) {
         final var beanWrapper = PropertyAccessorFactory.forBeanPropertyAccess(object);
         final var firstObj = beanWrapper.getPropertyValue(firstFieldName);
         final var secondObj = beanWrapper.getPropertyValue(secondFieldName);
-        final var isValid = Objects.equals(firstObj, secondObj);
+        final var isValid = areFieldsValid(firstObj, secondObj);
+
         if (!isValid) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(format(message, firstObj, secondObj))

--- a/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchConsiderCase.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchConsiderCase.java
@@ -27,11 +27,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @FieldMatch(first = "email", second = "confirmEmail", message = "The email fields must match")
  * })}
  */
-@Target({TYPE, ANNOTATION_TYPE})
-@Retention(RUNTIME)
-@Constraint(validatedBy = FieldMatchValidator.class)
-@Documented
-public @interface FieldMatch {
+@Constraint(validatedBy = FieldMatchConsiderCaseValidator.class)
+public @interface FieldMatchConsiderCase {
 
     String message() default "The {first} and {second} fields must be equal";
 
@@ -52,13 +49,13 @@ public @interface FieldMatch {
     /**
      * Defines several <code>@FieldMatch</code> annotations on the same element
      *
-     * @see FieldMatch
+     * @see FieldMatchConsiderCase
      */
     @Target({TYPE, ANNOTATION_TYPE})
     @Retention(RUNTIME)
     @Documented
     @interface List {
 
-        FieldMatch[] value();
+        FieldMatchConsiderCase[] value();
     }
 }

--- a/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchConsiderCaseValidator.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchConsiderCaseValidator.java
@@ -1,0 +1,17 @@
+package io.hexlet.typoreporter.service.dto;
+
+import java.util.Objects;
+
+public class FieldMatchConsiderCaseValidator extends AbstractFieldMatchValidator<FieldMatchConsiderCase> {
+    @Override
+    public void initialize(final FieldMatchConsiderCase constraintAnnotation) {
+        firstFieldName = constraintAnnotation.first();
+        secondFieldName = constraintAnnotation.second();
+        message = constraintAnnotation.message();
+    }
+
+    @Override
+    protected boolean areFieldsValid(Object firstField, Object secondField) {
+        return Objects.equals(firstField, secondField);
+    }
+}

--- a/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchIgnoreCase.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchIgnoreCase.java
@@ -1,0 +1,64 @@
+package io.hexlet.typoreporter.service.dto;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Validation annotation to validate that 2 fields have the same value.
+ * An array of fields and their matching confirmation fields can be supplied.
+ * <br>
+ * Example, compare 1 pair of fields:
+ * <br>
+ * {@code @FieldMatch(first = "password", second = "confirmPassword", message = "The password fields must match")}
+ * <br>
+ * Example, compare more than 1 pair of fields:
+ * <br>
+ * {@code @FieldMatch.List({
+ *
+ * @FieldMatch(first = "password", second = "confirmPassword", message = "The password fields must match"),
+ * @FieldMatch(first = "email", second = "confirmEmail", message = "The email fields must match")
+ * })}
+ */
+@Target({TYPE, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = FieldMatchIgnoreCaseValidator.class)
+@Documented
+public @interface FieldMatchIgnoreCase {
+
+    String message() default "The {first} and {second} fields must be equal";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * @return The first field
+     */
+    String first();
+
+    /**
+     * @return The second field
+     */
+    String second();
+
+    /**
+     * Defines several <code>@FieldMatch</code> annotations on the same element
+     *
+     * @see FieldMatchIgnoreCase
+     */
+    @Target({TYPE, ANNOTATION_TYPE})
+    @Retention(RUNTIME)
+    @Documented
+    @interface List {
+
+        FieldMatchIgnoreCase[] value();
+    }
+}

--- a/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchIgnoreCaseValidator.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchIgnoreCaseValidator.java
@@ -8,14 +8,7 @@ import java.util.Objects;
 
 import static java.text.MessageFormat.format;
 
-public class FieldMatchIgnoreCaseValidator implements ConstraintValidator<FieldMatchIgnoreCase, Object> {
-
-    protected String firstFieldName;
-
-    protected String secondFieldName;
-
-    protected String message;
-
+public class FieldMatchIgnoreCaseValidator extends AbstractFieldMatchValidator<FieldMatchIgnoreCase> {
     @Override
     public void initialize(final FieldMatchIgnoreCase constraintAnnotation) {
         firstFieldName = constraintAnnotation.first();
@@ -24,20 +17,7 @@ public class FieldMatchIgnoreCaseValidator implements ConstraintValidator<FieldM
     }
 
     @Override
-    public boolean isValid(final Object object, final ConstraintValidatorContext context) {
-        final var beanWrapper = PropertyAccessorFactory.forBeanPropertyAccess(object);
-        final var firstObj = beanWrapper.getPropertyValue(firstFieldName);
-        final var secondObj = beanWrapper.getPropertyValue(secondFieldName);
-        final var isValid = Objects.equals(firstObj.toString().toLowerCase(), secondObj.toString().toLowerCase());
-        if (!isValid) {
-            context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(format(message, firstObj, secondObj))
-                .addPropertyNode(firstFieldName)
-                .addConstraintViolation();
-            context.buildConstraintViolationWithTemplate(format(message, firstObj, secondObj))
-                .addPropertyNode(secondFieldName)
-                .addConstraintViolation();
-        }
-        return isValid;
+    protected boolean areFieldsValid(Object firstField, Object secondField) {
+        return Objects.equals(firstField.toString().toLowerCase(), secondField.toString().toLowerCase());
     }
 }

--- a/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchIgnoreCaseValidator.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchIgnoreCaseValidator.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 
 import static java.text.MessageFormat.format;
 
-public class FieldMatchValidator implements ConstraintValidator<FieldMatch, Object> {
+public class FieldMatchIgnoreCaseValidator implements ConstraintValidator<FieldMatchIgnoreCase, Object> {
 
     protected String firstFieldName;
 
@@ -17,7 +17,7 @@ public class FieldMatchValidator implements ConstraintValidator<FieldMatch, Obje
     protected String message;
 
     @Override
-    public void initialize(final FieldMatch constraintAnnotation) {
+    public void initialize(final FieldMatchIgnoreCase constraintAnnotation) {
         firstFieldName = constraintAnnotation.first();
         secondFieldName = constraintAnnotation.second();
         message = constraintAnnotation.message();
@@ -28,7 +28,7 @@ public class FieldMatchValidator implements ConstraintValidator<FieldMatch, Obje
         final var beanWrapper = PropertyAccessorFactory.forBeanPropertyAccess(object);
         final var firstObj = beanWrapper.getPropertyValue(firstFieldName);
         final var secondObj = beanWrapper.getPropertyValue(secondFieldName);
-        final var isValid = Objects.equals(firstObj, secondObj);
+        final var isValid = Objects.equals(firstObj.toString().toLowerCase(), secondObj.toString().toLowerCase());
         if (!isValid) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(format(message, firstObj, secondObj))

--- a/src/main/java/io/hexlet/typoreporter/service/dto/account/UpdatePassword.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/account/UpdatePassword.java
@@ -1,7 +1,7 @@
 package io.hexlet.typoreporter.service.dto.account;
 
 import io.hexlet.typoreporter.domain.account.constraint.AccountPassword;
-import io.hexlet.typoreporter.service.dto.FieldMatch;
+import io.hexlet.typoreporter.service.dto.FieldMatchConsiderCase;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -9,7 +9,7 @@ import lombok.experimental.Accessors;
 @Getter
 @Setter
 @Accessors(chain = true)
-@FieldMatch(first = "newPassword", second = "confirmNewPassword", message = "The password and it confirmation must match")
+@FieldMatchConsiderCase(first = "newPassword", second = "confirmNewPassword", message = "The password and it confirmation must match")
 public class UpdatePassword {
 
     private String oldPassword;

--- a/src/main/java/io/hexlet/typoreporter/service/dto/account/UpdateProfile.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/account/UpdateProfile.java
@@ -1,7 +1,7 @@
 package io.hexlet.typoreporter.service.dto.account;
 
 import io.hexlet.typoreporter.domain.account.constraint.AccountUsername;
-import io.hexlet.typoreporter.service.dto.FieldMatch;
+import io.hexlet.typoreporter.service.dto.FieldMatchConsiderCase;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -12,7 +12,7 @@ import lombok.experimental.Accessors;
 @Getter
 @Setter
 @Accessors(chain = true)
-@FieldMatch(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
+@FieldMatchConsiderCase(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
 public class UpdateProfile {
 
     @AccountUsername

--- a/src/main/java/io/hexlet/typoreporter/web/AccountController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/AccountController.java
@@ -42,16 +42,49 @@ public class AccountController {
         return "account/acc-info";
     }
 
+    //my add
+//    @GetMapping("/update")
+//    public String getProfilePage(final Model model,
+//                                 final Authentication authentication) {
+//        final String name = authentication.getName();
+//        final var updateProfile = accountService.getUpdateProfile(name);
+//        model.addAttribute("formModified", false);
+//        model.addAttribute("updateProfile", updateProfile);
+//        return "account/prof-update";
+//    }
     @GetMapping("/update")
     public String getProfilePage(final Model model,
                                  final Authentication authentication) {
-        final String name = authentication.getName();
-        final var updateProfile = accountService.getUpdateProfile(name);
+        final String email = authentication.getName();
+        final var updateProfile = accountService.getUpdateProfile(email);
         model.addAttribute("formModified", false);
         model.addAttribute("updateProfile", updateProfile);
         return "account/prof-update";
     }
+    //my add end
 
+    //my add
+//    @PutMapping("/update")
+//    public String putProfileUpdate(final Model model,
+//                                   final @Valid @ModelAttribute("updateProfile") UpdateProfile updateProfile,
+//                                   final BindingResult bindingResult,
+//                                   final Authentication authentication) {
+//        model.addAttribute("formModified", true);
+//        if (bindingResult.hasErrors()) {
+//            return "account/prof-update";
+//        }
+//        try {
+//            final String name = authentication.getName();
+//            Account updatedAccount = accountService.updateProfile(updateProfile, name);
+//            final var authenticated = UsernamePasswordAuthenticationToken.authenticated(updatedAccount.getUsername(),
+//                updatedAccount.getPassword(), List.of(() -> "ROLE_USER"));
+//            SecurityContextHolder.getContext().setAuthentication(authenticated);
+//            return "redirect:/account";
+//        } catch (AccountAlreadyExistException e) {
+//            bindingResult.addError(e.toFieldError("updateProfile"));
+//            return "account/prof-update";
+//        }
+//    }
     @PutMapping("/update")
     public String putProfileUpdate(final Model model,
                                    final @Valid @ModelAttribute("updateProfile") UpdateProfile updateProfile,
@@ -62,9 +95,9 @@ public class AccountController {
             return "account/prof-update";
         }
         try {
-            final String name = authentication.getName();
-            Account updatedAccount = accountService.updateProfile(updateProfile, name);
-            final var authenticated = UsernamePasswordAuthenticationToken.authenticated(updatedAccount.getUsername(),
+            final String email = authentication.getName();
+            Account updatedAccount = accountService.updateProfile(updateProfile, email);
+            final var authenticated = UsernamePasswordAuthenticationToken.authenticated(updatedAccount.getEmail(),
                 updatedAccount.getPassword(), List.of(() -> "ROLE_USER"));
             SecurityContextHolder.getContext().setAuthentication(authenticated);
             return "redirect:/account";
@@ -73,6 +106,7 @@ public class AccountController {
             return "account/prof-update";
         }
     }
+    //my add end
 
     @GetMapping("/password")
     public String getPasswordPage(final Model model) {
@@ -81,6 +115,28 @@ public class AccountController {
         return "account/pass-update";
     }
 
+    //my add
+//    @PutMapping("/password")
+//    public String putPasswordUpdate(final Model model,
+//                                    final @Valid @ModelAttribute("updatePassword") UpdatePassword updatePassword,
+//                                    final BindingResult bindingResult,
+//                                    final Authentication authentication) {
+//        model.addAttribute("formModified", true);
+//        if (bindingResult.hasErrors()) {
+//            return "account/pass-update";
+//        }
+//        try {
+//            final String name = authentication.getName();
+//            Account updatedAccount = accountService.updatePassword(updatePassword, name);
+//            final var authenticated = UsernamePasswordAuthenticationToken.authenticated(updatedAccount.getUsername(),
+//                updatedAccount.getPassword(), List.of(() -> "ROLE_USER"));
+//            SecurityContextHolder.getContext().setAuthentication(authenticated);
+//            return "redirect:/account";
+//        } catch (OldPasswordWrongException | NewPasswordTheSameException e) {
+//            bindingResult.addError(e.toFieldError("updatePassword"));
+//            return "account/pass-update";
+//        }
+//    }
     @PutMapping("/password")
     public String putPasswordUpdate(final Model model,
                                     final @Valid @ModelAttribute("updatePassword") UpdatePassword updatePassword,
@@ -91,9 +147,9 @@ public class AccountController {
             return "account/pass-update";
         }
         try {
-            final String name = authentication.getName();
-            Account updatedAccount = accountService.updatePassword(updatePassword, name);
-            final var authenticated = UsernamePasswordAuthenticationToken.authenticated(updatedAccount.getUsername(),
+            final String email = authentication.getName();
+            Account updatedAccount = accountService.updatePassword(updatePassword, email);
+            final var authenticated = UsernamePasswordAuthenticationToken.authenticated(updatedAccount.getEmail(),
                 updatedAccount.getPassword(), List.of(() -> "ROLE_USER"));
             SecurityContextHolder.getContext().setAuthentication(authenticated);
             return "redirect:/account";
@@ -102,6 +158,7 @@ public class AccountController {
             return "account/pass-update";
         }
     }
+    //my add end
 
     @ExceptionHandler(value = AccountNotFoundException.class)
     public String accountNotFoundException(AccountNotFoundException e) {

--- a/src/main/java/io/hexlet/typoreporter/web/AccountController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/AccountController.java
@@ -33,14 +33,24 @@ public class AccountController {
 
     private final AccountService accountService;
 
+    //my add
+    //    @GetMapping
+//    public String getAccountInfoPage(final Model model, final Authentication authentication) {
+//        final var accountInfo = accountService.getInfoAccount(authentication.getName());
+//        final var workspaceInfos = accountService.getWorkspacesInfoListByUsername(accountInfo.username());
+//        model.addAttribute("workspaceRoleInfoList", workspaceInfos);
+//        model.addAttribute("accInfo", accountInfo);
+//        return "account/acc-info";
+//    }
     @GetMapping
     public String getAccountInfoPage(final Model model, final Authentication authentication) {
         final var accountInfo = accountService.getInfoAccount(authentication.getName());
-        final var workspaceInfos = accountService.getWorkspacesInfoListByUsername(accountInfo.username());
+        final var workspaceInfos = accountService.getWorkspacesInfoListByEmail(accountInfo.email());
         model.addAttribute("workspaceRoleInfoList", workspaceInfos);
         model.addAttribute("accInfo", accountInfo);
         return "account/acc-info";
     }
+    //my add end
 
     //my add
 //    @GetMapping("/update")

--- a/src/main/java/io/hexlet/typoreporter/web/AccountController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/AccountController.java
@@ -33,15 +33,6 @@ public class AccountController {
 
     private final AccountService accountService;
 
-    //my add
-    //    @GetMapping
-//    public String getAccountInfoPage(final Model model, final Authentication authentication) {
-//        final var accountInfo = accountService.getInfoAccount(authentication.getName());
-//        final var workspaceInfos = accountService.getWorkspacesInfoListByUsername(accountInfo.username());
-//        model.addAttribute("workspaceRoleInfoList", workspaceInfos);
-//        model.addAttribute("accInfo", accountInfo);
-//        return "account/acc-info";
-//    }
     @GetMapping
     public String getAccountInfoPage(final Model model, final Authentication authentication) {
         final var accountInfo = accountService.getInfoAccount(authentication.getName());
@@ -50,18 +41,7 @@ public class AccountController {
         model.addAttribute("accInfo", accountInfo);
         return "account/acc-info";
     }
-    //my add end
 
-    //my add
-//    @GetMapping("/update")
-//    public String getProfilePage(final Model model,
-//                                 final Authentication authentication) {
-//        final String name = authentication.getName();
-//        final var updateProfile = accountService.getUpdateProfile(name);
-//        model.addAttribute("formModified", false);
-//        model.addAttribute("updateProfile", updateProfile);
-//        return "account/prof-update";
-//    }
     @GetMapping("/update")
     public String getProfilePage(final Model model,
                                  final Authentication authentication) {
@@ -71,30 +51,7 @@ public class AccountController {
         model.addAttribute("updateProfile", updateProfile);
         return "account/prof-update";
     }
-    //my add end
 
-    //my add
-//    @PutMapping("/update")
-//    public String putProfileUpdate(final Model model,
-//                                   final @Valid @ModelAttribute("updateProfile") UpdateProfile updateProfile,
-//                                   final BindingResult bindingResult,
-//                                   final Authentication authentication) {
-//        model.addAttribute("formModified", true);
-//        if (bindingResult.hasErrors()) {
-//            return "account/prof-update";
-//        }
-//        try {
-//            final String name = authentication.getName();
-//            Account updatedAccount = accountService.updateProfile(updateProfile, name);
-//            final var authenticated = UsernamePasswordAuthenticationToken.authenticated(updatedAccount.getUsername(),
-//                updatedAccount.getPassword(), List.of(() -> "ROLE_USER"));
-//            SecurityContextHolder.getContext().setAuthentication(authenticated);
-//            return "redirect:/account";
-//        } catch (AccountAlreadyExistException e) {
-//            bindingResult.addError(e.toFieldError("updateProfile"));
-//            return "account/prof-update";
-//        }
-//    }
     @PutMapping("/update")
     public String putProfileUpdate(final Model model,
                                    final @Valid @ModelAttribute("updateProfile") UpdateProfile updateProfile,
@@ -116,7 +73,6 @@ public class AccountController {
             return "account/prof-update";
         }
     }
-    //my add end
 
     @GetMapping("/password")
     public String getPasswordPage(final Model model) {
@@ -125,28 +81,6 @@ public class AccountController {
         return "account/pass-update";
     }
 
-    //my add
-//    @PutMapping("/password")
-//    public String putPasswordUpdate(final Model model,
-//                                    final @Valid @ModelAttribute("updatePassword") UpdatePassword updatePassword,
-//                                    final BindingResult bindingResult,
-//                                    final Authentication authentication) {
-//        model.addAttribute("formModified", true);
-//        if (bindingResult.hasErrors()) {
-//            return "account/pass-update";
-//        }
-//        try {
-//            final String name = authentication.getName();
-//            Account updatedAccount = accountService.updatePassword(updatePassword, name);
-//            final var authenticated = UsernamePasswordAuthenticationToken.authenticated(updatedAccount.getUsername(),
-//                updatedAccount.getPassword(), List.of(() -> "ROLE_USER"));
-//            SecurityContextHolder.getContext().setAuthentication(authenticated);
-//            return "redirect:/account";
-//        } catch (OldPasswordWrongException | NewPasswordTheSameException e) {
-//            bindingResult.addError(e.toFieldError("updatePassword"));
-//            return "account/pass-update";
-//        }
-//    }
     @PutMapping("/password")
     public String putPasswordUpdate(final Model model,
                                     final @Valid @ModelAttribute("updatePassword") UpdatePassword updatePassword,
@@ -168,7 +102,6 @@ public class AccountController {
             return "account/pass-update";
         }
     }
-    //my add end
 
     @ExceptionHandler(value = AccountNotFoundException.class)
     public String accountNotFoundException(AccountNotFoundException e) {

--- a/src/main/java/io/hexlet/typoreporter/web/IndexController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/IndexController.java
@@ -19,8 +19,12 @@ public class IndexController {
     @GetMapping("/workspaces")
     public String index(final Model model, Principal principal) {
         if (principal != null) {
-            final var username = principal.getName();
-            final var wksInfoList = workspaceService.getAllWorkspacesInfoByUsername(username);
+            //my add
+//            final var username = principal.getName();
+            //            final var wksInfoList = workspaceService.getAllWorkspacesInfoByUsername(username);
+            final var email = principal.getName();
+            final var wksInfoList = workspaceService.getAllWorkspacesInfoByEmail(email);
+            //my add end
             model.addAttribute("wksInfoList", wksInfoList);
         }
         return "workspaces";

--- a/src/main/java/io/hexlet/typoreporter/web/IndexController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/IndexController.java
@@ -19,12 +19,8 @@ public class IndexController {
     @GetMapping("/workspaces")
     public String index(final Model model, Principal principal) {
         if (principal != null) {
-            //my add
-//            final var username = principal.getName();
-            //            final var wksInfoList = workspaceService.getAllWorkspacesInfoByUsername(username);
             final var email = principal.getName();
             final var wksInfoList = workspaceService.getAllWorkspacesInfoByEmail(email);
-            //my add end
             model.addAttribute("wksInfoList", wksInfoList);
         }
         return "workspaces";

--- a/src/main/java/io/hexlet/typoreporter/web/SignupController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/SignupController.java
@@ -62,10 +62,7 @@ public class SignupController {
         try {
             newAccount = signupAccountUseCase.signup(signupAccountMapper.toSignupAccount(signupAccountModel));
             final var authentication = UsernamePasswordAuthenticationToken.
-                //my add
-//                authenticated(newAccount.username(), null, List.of(AccountRole.ROLE_GUEST::name));
                 authenticated(newAccount.email(), null, List.of(AccountRole.ROLE_GUEST::name));
-            //my add end
             autoLoginAfterSignup(request, response, authentication);
             return "redirect:/workspaces";
         } catch (UsernameAlreadyExistException e) {

--- a/src/main/java/io/hexlet/typoreporter/web/SignupController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/SignupController.java
@@ -62,7 +62,10 @@ public class SignupController {
         try {
             newAccount = signupAccountUseCase.signup(signupAccountMapper.toSignupAccount(signupAccountModel));
             final var authentication = UsernamePasswordAuthenticationToken.
-                authenticated(newAccount.username(), null, List.of(AccountRole.ROLE_GUEST::name));
+                //my add
+//                authenticated(newAccount.username(), null, List.of(AccountRole.ROLE_GUEST::name));
+                authenticated(newAccount.email(), null, List.of(AccountRole.ROLE_GUEST::name));
+            //my add end
             autoLoginAfterSignup(request, response, authentication);
             return "redirect:/workspaces";
         } catch (UsernameAlreadyExistException e) {

--- a/src/main/java/io/hexlet/typoreporter/web/WorkspaceController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/WorkspaceController.java
@@ -261,7 +261,10 @@ public class WorkspaceController {
         List<Account> nonLinkedAccounts = getNonLinkedAccounts(allAccounts, linkedAccounts);
         final Account authenticatedAccount = getAccountFromAuthentication();
         final boolean accountIsAdminRole = workspaceService.isAdminRoleUserInWorkspace(wksId,
-            authenticatedAccount.getUsername());
+            //my add
+//            authenticatedAccount.getUsername());
+            authenticatedAccount.getEmail());
+            //my add end
         List<Account> excludeDeleteAccounts = Collections.singletonList(authenticatedAccount);
         Page<Account> userPage = new PageImpl<>(linkedAccounts, pageable, linkedAccounts.size());
         var sort = userPage.getSort()
@@ -338,6 +341,9 @@ public class WorkspaceController {
 
     private Account getAccountFromAuthentication() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return accountService.findByUsername(authentication.getName());
+        //my add
+        // return accountService.findByUsername(authentication.getName());
+         return accountService.findByEmail(authentication.getName());
+        //my add end
     }
 }

--- a/src/main/java/io/hexlet/typoreporter/web/WorkspaceController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/WorkspaceController.java
@@ -94,14 +94,14 @@ public class WorkspaceController {
                                           Principal principal,
                                           @Valid @ModelAttribute CreateWorkspace createWorkspace,
                                           BindingResult bindingResult) {
-        String userName = principal.getName();
+        String email = principal.getName();
         model.addAttribute("formModified", true);
         if (bindingResult.hasErrors()) {
             model.addAttribute("createWorkspace", createWorkspace);
             return "create-workspace";
         }
         try {
-            workspaceService.createWorkspace(createWorkspace, userName);
+            workspaceService.createWorkspace(createWorkspace, email);
         } catch (WorkspaceAlreadyExistException e) {
             bindingResult.addError(e.toFieldError("createWorkspace"));
             return "create-workspace";

--- a/src/main/java/io/hexlet/typoreporter/web/WorkspaceController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/WorkspaceController.java
@@ -261,10 +261,7 @@ public class WorkspaceController {
         List<Account> nonLinkedAccounts = getNonLinkedAccounts(allAccounts, linkedAccounts);
         final Account authenticatedAccount = getAccountFromAuthentication();
         final boolean accountIsAdminRole = workspaceService.isAdminRoleUserInWorkspace(wksId,
-            //my add
-//            authenticatedAccount.getUsername());
             authenticatedAccount.getEmail());
-            //my add end
         List<Account> excludeDeleteAccounts = Collections.singletonList(authenticatedAccount);
         Page<Account> userPage = new PageImpl<>(linkedAccounts, pageable, linkedAccounts.size());
         var sort = userPage.getSort()
@@ -341,9 +338,6 @@ public class WorkspaceController {
 
     private Account getAccountFromAuthentication() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        //my add
-        // return accountService.findByUsername(authentication.getName());
          return accountService.findByEmail(authentication.getName());
-        //my add end
     }
 }

--- a/src/main/java/io/hexlet/typoreporter/web/WorkspaceSettingsController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/WorkspaceSettingsController.java
@@ -57,7 +57,10 @@ public class WorkspaceSettingsController {
 
         final Account authenticatedAccount = getAccountFromAuthentication();
         final boolean accountIsAdminRole = workspaceService.isAdminRoleUserInWorkspace(wksId,
-            authenticatedAccount.getUsername());
+            //my add
+//            authenticatedAccount.getUsername());
+            authenticatedAccount.getEmail());
+            //my add end
         model.addAttribute("isAdmin", accountIsAdminRole);
 
         getStatisticDataToModel(model, wksId);
@@ -117,8 +120,14 @@ public class WorkspaceSettingsController {
         model.addAttribute("wksId", wksId);
     }
 
+    //my add
+//    private Account getAccountFromAuthentication() {
+//        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        return accountService.findByUsername(authentication.getName());
+//    }
     private Account getAccountFromAuthentication() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return accountService.findByUsername(authentication.getName());
+        return accountService.findByEmail(authentication.getName());
     }
+    //my add end
 }

--- a/src/main/java/io/hexlet/typoreporter/web/WorkspaceSettingsController.java
+++ b/src/main/java/io/hexlet/typoreporter/web/WorkspaceSettingsController.java
@@ -57,10 +57,7 @@ public class WorkspaceSettingsController {
 
         final Account authenticatedAccount = getAccountFromAuthentication();
         final boolean accountIsAdminRole = workspaceService.isAdminRoleUserInWorkspace(wksId,
-            //my add
-//            authenticatedAccount.getUsername());
             authenticatedAccount.getEmail());
-            //my add end
         model.addAttribute("isAdmin", accountIsAdminRole);
 
         getStatisticDataToModel(model, wksId);
@@ -120,14 +117,8 @@ public class WorkspaceSettingsController {
         model.addAttribute("wksId", wksId);
     }
 
-    //my add
-//    private Account getAccountFromAuthentication() {
-//        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-//        return accountService.findByUsername(authentication.getName());
-//    }
     private Account getAccountFromAuthentication() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         return accountService.findByEmail(authentication.getName());
     }
-    //my add end
 }

--- a/src/main/java/io/hexlet/typoreporter/web/exception/AccountNotFoundException.java
+++ b/src/main/java/io/hexlet/typoreporter/web/exception/AccountNotFoundException.java
@@ -7,11 +7,7 @@ import static java.text.MessageFormat.format;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 public class AccountNotFoundException extends ErrorResponseException {
-
-    //my add
-//    private static final String NOT_FOUND_MSG = "Account with email or userName=''{0}'' not found";
     private static final String NOT_FOUND_MSG = "Account with email=''{0}'' not found";
-    //my add end
 
     public AccountNotFoundException(final String emailOrUserName) {
         super(NOT_FOUND, ProblemDetail.forStatusAndDetail(NOT_FOUND, "Account not found"), null,

--- a/src/main/java/io/hexlet/typoreporter/web/exception/AccountNotFoundException.java
+++ b/src/main/java/io/hexlet/typoreporter/web/exception/AccountNotFoundException.java
@@ -8,7 +8,10 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 public class AccountNotFoundException extends ErrorResponseException {
 
-    private static final String NOT_FOUND_MSG = "Account with email or userName=''{0}'' not found";
+    //my add
+//    private static final String NOT_FOUND_MSG = "Account with email or userName=''{0}'' not found";
+    private static final String NOT_FOUND_MSG = "Account with email=''{0}'' not found";
+    //my add end
 
     public AccountNotFoundException(final String emailOrUserName) {
         super(NOT_FOUND, ProblemDetail.forStatusAndDetail(NOT_FOUND, "Account not found"), null,

--- a/src/main/java/io/hexlet/typoreporter/web/model/SignupAccountModel.java
+++ b/src/main/java/io/hexlet/typoreporter/web/model/SignupAccountModel.java
@@ -2,7 +2,7 @@ package io.hexlet.typoreporter.web.model;
 
 import io.hexlet.typoreporter.domain.account.constraint.AccountPassword;
 import io.hexlet.typoreporter.domain.account.constraint.AccountUsername;
-import io.hexlet.typoreporter.service.dto.FieldMatch;
+import io.hexlet.typoreporter.service.dto.FieldMatchConsiderCase;
 import io.hexlet.typoreporter.service.dto.FieldMatchIgnoreCase;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -21,7 +21,7 @@ import lombok.ToString;
 //    @FieldMatch(first = "password", second = "confirmPassword", message = "The password and it confirmation must match"),
 //    @FieldMatch(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
 //})
-@FieldMatch(first = "password", second = "confirmPassword", message = "The password and it confirmation must match")
+@FieldMatchConsiderCase(first = "password", second = "confirmPassword", message = "The password and it confirmation must match")
 @FieldMatchIgnoreCase(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
 
 @ToString

--- a/src/main/java/io/hexlet/typoreporter/web/model/SignupAccountModel.java
+++ b/src/main/java/io/hexlet/typoreporter/web/model/SignupAccountModel.java
@@ -3,6 +3,7 @@ package io.hexlet.typoreporter.web.model;
 import io.hexlet.typoreporter.domain.account.constraint.AccountPassword;
 import io.hexlet.typoreporter.domain.account.constraint.AccountUsername;
 import io.hexlet.typoreporter.service.dto.FieldMatch;
+import io.hexlet.typoreporter.service.dto.FieldMatchIgnoreCase;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -16,10 +17,13 @@ import lombok.ToString;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@FieldMatch.List({
-    @FieldMatch(first = "password", second = "confirmPassword", message = "The password and it confirmation must match"),
-    @FieldMatch(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
-})
+//@FieldMatch.List({
+//    @FieldMatch(first = "password", second = "confirmPassword", message = "The password and it confirmation must match"),
+//    @FieldMatch(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
+//})
+@FieldMatch(first = "password", second = "confirmPassword", message = "The password and it confirmation must match")
+@FieldMatchIgnoreCase(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
+
 @ToString
 public class SignupAccountModel {
 

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -10,9 +10,9 @@
         <div class="alert alert-warning" role="alert" th:if="${param.logout}" th:text="#{alert.logout}"></div>
         <form method="post" th:action="@{/login}">
             <div class="form-floating mb-3">
-                <input autofocus class="form-control" id="inputUsername"
-                       name="username" placeholder="Username" required type="text">
-                <label for="inputUsername" th:text="#{username}"></label>
+                <input autofocus class="form-control" id="inputEmail"
+                       name="email" placeholder="Email" required type="text">
+                <label for="inputEmail" th:text="#{email}"></label>
             </div>
             <div class="form-floating mb-3">
                 <input class="form-control" id="inputPassword" name="password"

--- a/src/test/java/io/hexlet/typoreporter/repository/AccountRepositoryIT.java
+++ b/src/test/java/io/hexlet/typoreporter/repository/AccountRepositoryIT.java
@@ -64,12 +64,4 @@ public class AccountRepositoryIT {
     void getAccountByEmailNotExist(final String email) {
         assertThat(accountRepository.findAccountByEmail(email)).isEmpty();
     }
-
-    @ParameterizedTest
-    @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getAccountUsernameExist")
-    void getAccountByUsername(final String username) {
-        final var account = accountRepository.findAccountByUsername(username);
-        assertThat(account).isNotEmpty();
-        assertThat(account.map(Account::getUsername).orElseThrow()).isEqualTo(username);
-    }
 }

--- a/src/test/java/io/hexlet/typoreporter/repository/WorkspaceRoleRepositoryIT.java
+++ b/src/test/java/io/hexlet/typoreporter/repository/WorkspaceRoleRepositoryIT.java
@@ -58,14 +58,24 @@ public class WorkspaceRoleRepositoryIT {
         assertThat(workspaceRoles.get(0).getAccount().getId()).isEqualTo(accountId);
     }
 
+    //my add
+//    @ParameterizedTest
+//    @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getAccountUsernameExist")
+//    void getWorkspaceRolesByAccountIdIsSuccessful(final String username) {
+//        List<WorkspaceRole> workspaceRoles = workspaceRoleRepository.getWorkspaceRolesByAccountUsername(username);
+//
+//        assertThat(workspaceRoles).isNotEmpty();
+//        assertThat(workspaceRoles.get(0).getAccount().getUsername()).isEqualTo(username);
+//    }
     @ParameterizedTest
-    @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getAccountUsernameExist")
-    void getWorkspaceRolesByAccountIdIsSuccessful(final String username) {
-        List<WorkspaceRole> workspaceRoles = workspaceRoleRepository.getWorkspaceRolesByAccountUsername(username);
+    @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getAccountEmailExist")
+    void getWorkspaceRolesByAccountIdIsSuccessful(final String email) {
+        List<WorkspaceRole> workspaceRoles = workspaceRoleRepository.getWorkspaceRolesByAccountEmail(email);
 
         assertThat(workspaceRoles).isNotEmpty();
-        assertThat(workspaceRoles.get(0).getAccount().getUsername()).isEqualTo(username);
+        assertThat(workspaceRoles.get(0).getAccount().getEmail()).isEqualTo(email);
     }
+    //my add end
 
     @ParameterizedTest
     @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspacesIdExist")

--- a/src/test/java/io/hexlet/typoreporter/repository/WorkspaceRoleRepositoryIT.java
+++ b/src/test/java/io/hexlet/typoreporter/repository/WorkspaceRoleRepositoryIT.java
@@ -58,15 +58,6 @@ public class WorkspaceRoleRepositoryIT {
         assertThat(workspaceRoles.get(0).getAccount().getId()).isEqualTo(accountId);
     }
 
-    //my add
-//    @ParameterizedTest
-//    @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getAccountUsernameExist")
-//    void getWorkspaceRolesByAccountIdIsSuccessful(final String username) {
-//        List<WorkspaceRole> workspaceRoles = workspaceRoleRepository.getWorkspaceRolesByAccountUsername(username);
-//
-//        assertThat(workspaceRoles).isNotEmpty();
-//        assertThat(workspaceRoles.get(0).getAccount().getUsername()).isEqualTo(username);
-//    }
     @ParameterizedTest
     @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getAccountEmailExist")
     void getWorkspaceRolesByAccountIdIsSuccessful(final String email) {
@@ -75,7 +66,6 @@ public class WorkspaceRoleRepositoryIT {
         assertThat(workspaceRoles).isNotEmpty();
         assertThat(workspaceRoles.get(0).getAccount().getEmail()).isEqualTo(email);
     }
-    //my add end
 
     @ParameterizedTest
     @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspacesIdExist")

--- a/src/test/java/io/hexlet/typoreporter/test/factory/EntitiesFactory.java
+++ b/src/test/java/io/hexlet/typoreporter/test/factory/EntitiesFactory.java
@@ -51,34 +51,67 @@ public class EntitiesFactory {
         return Stream.of(WORKSPACE_101_ID, WORKSPACE_102_ID, WORKSPACE_103_ID);
     }
 
+    //my add
+    //    public static Stream<Arguments> getWorkspacesAndUsersRelated() {
+//        return Stream.of(
+//            Arguments.of(WORKSPACE_101_ID, ACCOUNT_101_USERNAME),
+//            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME),
+//            Arguments.of(WORKSPACE_103_ID, ACCOUNT_103_USERNAME)
+//        );
+//    }
     public static Stream<Arguments> getWorkspacesAndUsersRelated() {
         return Stream.of(
-            Arguments.of(WORKSPACE_101_ID, ACCOUNT_101_USERNAME),
-            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME),
-            Arguments.of(WORKSPACE_103_ID, ACCOUNT_103_USERNAME)
+            Arguments.of(WORKSPACE_101_ID, ACCOUNT_101_EMAIL),
+            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_EMAIL),
+            Arguments.of(WORKSPACE_103_ID, ACCOUNT_103_EMAIL)
         );
     }
+    //my add end
 
+    //my add
+//    public static Stream<Arguments> getWorkspaceAndAdminRelated() {
+//        return Stream.of(
+//            Arguments.of(WORKSPACE_103_ID, ACCOUNT_103_USERNAME)
+//        );
+//    }
     public static Stream<Arguments> getWorkspaceAndAdminRelated() {
         return Stream.of(
-            Arguments.of(WORKSPACE_103_ID, ACCOUNT_103_USERNAME)
+            Arguments.of(WORKSPACE_103_ID, ACCOUNT_103_EMAIL)
         );
     }
+    //my add end
 
+    //my add
+//    public static Stream<Arguments> getWorkspaceAndNotAdminRelated() {
+//        return Stream.of(
+//            Arguments.of(WORKSPACE_101_ID, ACCOUNT_101_USERNAME)
+//        );
+//    }
     public static Stream<Arguments> getWorkspaceAndNotAdminRelated() {
         return Stream.of(
-            Arguments.of(WORKSPACE_101_ID, ACCOUNT_101_USERNAME)
+            Arguments.of(WORKSPACE_101_ID, ACCOUNT_101_EMAIL)
         );
     }
+    //my add end
 
+    //my add
+//    public static Stream<Arguments> getWorkspacesAndUsersAndTypoStatusRelated() {
+//        return Stream.of(
+//            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "REPORTED"),
+//            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "IN_PROGRESS"),
+//            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "RESOLVED"),
+//            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "CANCELED")
+//        );
+//    }
     public static Stream<Arguments> getWorkspacesAndUsersAndTypoStatusRelated() {
         return Stream.of(
-            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "REPORTED"),
-            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "IN_PROGRESS"),
-            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "RESOLVED"),
-            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "CANCELED")
+            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_EMAIL, "REPORTED"),
+            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_EMAIL, "IN_PROGRESS"),
+            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_EMAIL, "RESOLVED"),
+            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_EMAIL, "CANCELED")
         );
     }
+    //my add end
 
     public static Stream<Arguments> getWorkspacesAndUsersNotRelated() {
         return Stream.of(

--- a/src/test/java/io/hexlet/typoreporter/test/factory/EntitiesFactory.java
+++ b/src/test/java/io/hexlet/typoreporter/test/factory/EntitiesFactory.java
@@ -14,26 +14,13 @@ import static java.time.Instant.now;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 public class EntitiesFactory {
-
-    public static final String WORKSPACE_101_NAME = "wks-name";
-
     public static final String WORKSPACE_101_TOKEN = "abb4f3ab-1994-4264-bc6f-7cd1aa13dc0a";
-
-    public static final String WORKSPACE_102_NAME = "wks-test";
-
-    public static final String WORKSPACE_103_NAME = "wks-empty";
 
     public static final String ACCOUNT_101_EMAIL = "test101@gmail.com";
 
     public static final String ACCOUNT_102_EMAIL = "test102@gmail.com";
 
     public static final String ACCOUNT_103_EMAIL = "test103@gmail.com";
-
-    public static final String ACCOUNT_101_USERNAME = "test1";
-
-    public static final String ACCOUNT_102_USERNAME = "test2";
-
-    public static final String ACCOUNT_103_USERNAME = "test3";
 
     public static final Long ACCOUNT_101_ID = 101L;
 
@@ -51,14 +38,6 @@ public class EntitiesFactory {
         return Stream.of(WORKSPACE_101_ID, WORKSPACE_102_ID, WORKSPACE_103_ID);
     }
 
-    //my add
-    //    public static Stream<Arguments> getWorkspacesAndUsersRelated() {
-//        return Stream.of(
-//            Arguments.of(WORKSPACE_101_ID, ACCOUNT_101_USERNAME),
-//            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME),
-//            Arguments.of(WORKSPACE_103_ID, ACCOUNT_103_USERNAME)
-//        );
-//    }
     public static Stream<Arguments> getWorkspacesAndUsersRelated() {
         return Stream.of(
             Arguments.of(WORKSPACE_101_ID, ACCOUNT_101_EMAIL),
@@ -66,43 +45,19 @@ public class EntitiesFactory {
             Arguments.of(WORKSPACE_103_ID, ACCOUNT_103_EMAIL)
         );
     }
-    //my add end
 
-    //my add
-//    public static Stream<Arguments> getWorkspaceAndAdminRelated() {
-//        return Stream.of(
-//            Arguments.of(WORKSPACE_103_ID, ACCOUNT_103_USERNAME)
-//        );
-//    }
     public static Stream<Arguments> getWorkspaceAndAdminRelated() {
         return Stream.of(
             Arguments.of(WORKSPACE_103_ID, ACCOUNT_103_EMAIL)
         );
     }
-    //my add end
 
-    //my add
-//    public static Stream<Arguments> getWorkspaceAndNotAdminRelated() {
-//        return Stream.of(
-//            Arguments.of(WORKSPACE_101_ID, ACCOUNT_101_USERNAME)
-//        );
-//    }
     public static Stream<Arguments> getWorkspaceAndNotAdminRelated() {
         return Stream.of(
             Arguments.of(WORKSPACE_101_ID, ACCOUNT_101_EMAIL)
         );
     }
-    //my add end
 
-    //my add
-//    public static Stream<Arguments> getWorkspacesAndUsersAndTypoStatusRelated() {
-//        return Stream.of(
-//            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "REPORTED"),
-//            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "IN_PROGRESS"),
-//            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "RESOLVED"),
-//            Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_USERNAME, "CANCELED")
-//        );
-//    }
     public static Stream<Arguments> getWorkspacesAndUsersAndTypoStatusRelated() {
         return Stream.of(
             Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_EMAIL, "REPORTED"),
@@ -111,13 +66,12 @@ public class EntitiesFactory {
             Arguments.of(WORKSPACE_102_ID, ACCOUNT_102_EMAIL, "CANCELED")
         );
     }
-    //my add end
 
     public static Stream<Arguments> getWorkspacesAndUsersNotRelated() {
         return Stream.of(
-            Arguments.of(WORKSPACE_101_ID, ACCOUNT_103_USERNAME),
-            Arguments.of(WORKSPACE_102_ID, ACCOUNT_101_USERNAME),
-            Arguments.of(WORKSPACE_103_ID, ACCOUNT_102_USERNAME)
+            Arguments.of(WORKSPACE_101_ID, ACCOUNT_103_EMAIL),
+            Arguments.of(WORKSPACE_102_ID, ACCOUNT_101_EMAIL),
+            Arguments.of(WORKSPACE_103_ID, ACCOUNT_102_EMAIL)
         );
     }
 
@@ -230,10 +184,6 @@ public class EntitiesFactory {
 
     public static Stream<? extends Identifiable<Long>> getEntities() {
         return Stream.concat(getTypos(), getWorkspaces());
-    }
-
-    public static Stream<String> getAccountUsernameExist() {
-        return Stream.of(ACCOUNT_101_USERNAME, ACCOUNT_102_USERNAME, ACCOUNT_103_USERNAME);
     }
 
     public static Stream<Long> getAccountsIdExist() {

--- a/src/test/java/io/hexlet/typoreporter/web/AccountControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/AccountControllerIT.java
@@ -21,6 +21,7 @@ import static io.hexlet.typoreporter.test.Constraints.POSTGRES_IMAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -67,7 +68,7 @@ public class AccountControllerIT {
             .isEqualTo(correctEmailDomain);
 
         String wrongEmailDomain = "test@test";
-        mockMvc.perform(post("/update")
+        mockMvc.perform(post("/account/update")
             .param("username", userName)
             .param("email", wrongEmailDomain)
             .param("confirmEmail", wrongEmailDomain)
@@ -79,5 +80,35 @@ public class AccountControllerIT {
         assertThat(accountRepository.findAccountByEmail(wrongEmailDomain)).isEmpty();
         assertThat(accountRepository.findAccountByEmail(correctEmailDomain).orElseThrow().getEmail())
             .isEqualTo(correctEmailDomain);
+    }
+
+    @Test
+    void updateAccountEmailUsingDifferentCase() throws Exception {
+        final String username = "testUser";
+        final String emailUpperCase = "TEST@TEST.RU";
+        final String emailMixedCase = "TEST@test.Ru";
+        final String emailLowerCase = "test@test.ru";
+        final String password = "_Qwe1234";
+
+        mockMvc.perform(post("/signup")
+            .param("username", username)
+            .param("email", emailMixedCase)
+            .param("confirmEmail", emailMixedCase)
+            .param("password", password)
+            .param("confirmPassword", password)
+            .param("firstName", username)
+            .param("lastName", username)
+            .with(csrf()));
+        assertThat(accountRepository.findAccountByEmail(emailLowerCase)).isNotEmpty();
+
+        mockMvc.perform(put("/account/update")
+            .param("firstName", username)
+            .param("lastName", username)
+            .param("username", username)
+            .param("email", emailUpperCase)
+            .param("confirmEmail", emailUpperCase)
+            .with(csrf()));
+        assertThat(accountRepository.findAccountByEmail(emailUpperCase)).isEmpty();
+        assertThat(accountRepository.findAccountByEmail(emailLowerCase)).isNotEmpty();
     }
 }

--- a/src/test/java/io/hexlet/typoreporter/web/LoginIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/LoginIT.java
@@ -1,0 +1,99 @@
+package io.hexlet.typoreporter.web;
+
+import com.github.database.rider.core.api.configuration.DBUnit;
+import com.github.database.rider.spring.api.DBRider;
+import io.hexlet.typoreporter.repository.AccountRepository;
+import io.hexlet.typoreporter.test.DBUnitEnumPostgres;
+import io.hexlet.typoreporter.web.model.SignupAccountModel;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import static com.github.database.rider.core.api.configuration.Orthography.LOWERCASE;
+import static io.hexlet.typoreporter.test.Constraints.POSTGRES_IMAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@Transactional
+@DBRider
+@DBUnit(caseInsensitiveStrategy = LOWERCASE, dataTypeFactoryClass = DBUnitEnumPostgres.class, cacheConnection = false)
+class LoginIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>(POSTGRES_IMAGE)
+        .withPassword("inmemory")
+        .withUsername("inmemory");
+
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
+        registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    private final String EMAIL_UPPER_CASE = "EMAIL_ADDRESS@GOOGLE.COM";
+    private final String EMAIL_LOWER_CASE = EMAIL_UPPER_CASE.toLowerCase();
+
+    private SignupAccountModel model = new SignupAccountModel(
+        "model_upper_case",
+        EMAIL_UPPER_CASE, EMAIL_UPPER_CASE,
+        "password","password",
+        "firstName", "lastName");
+
+    @Test
+    void loginByEmailInAnyCaseSuccess() throws Exception {
+        assertThat(accountRepository.findAccountByEmail(EMAIL_LOWER_CASE)).isEmpty();
+
+        mockMvc.perform(post("/signup")
+            .param("username", model.getUsername())
+            .param("email", model.getEmail())
+            .param("confirmEmail", model.getEmail())
+            .param("password", model.getPassword())
+            .param("confirmPassword", model.getPassword())
+            .param("firstName", model.getFirstName())
+            .param("lastName", model.getLastName())
+            .with(csrf()));
+        assertThat(accountRepository.findAccountByEmail(EMAIL_LOWER_CASE)).isNotEmpty();
+
+        String locationHeaderStrLowerCaseEmail = mockMvc.perform(post("/login")
+            .param("email", EMAIL_LOWER_CASE)
+            .param("password", model.getPassword())
+            .with(csrf()))
+        .andReturn()
+        .getResponse()
+        .getHeader("Location");
+        assertThat(locationHeaderStrLowerCaseEmail).contains("workspaces");
+
+        String locationHeaderStrBadEmail = mockMvc.perform(post("/login")
+            .param("email", "bad@email.com")
+            .param("password", model.getPassword())
+            .with(csrf())
+        ).andReturn().getResponse().getHeader("Location");
+        assertThat(locationHeaderStrBadEmail).doesNotContain ("workspaces");
+        assertThat(locationHeaderStrBadEmail).contains("login");
+
+        String locationHeaderStrUpperCaseEmail = mockMvc.perform(post("/login")
+            .param("email", EMAIL_UPPER_CASE)
+            .param("password", model.getPassword())
+            .with(csrf())
+        ).andReturn().getResponse().getHeader("Location");
+        assertThat(locationHeaderStrUpperCaseEmail).contains("workspaces");
+    }
+}

--- a/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
@@ -56,13 +56,13 @@ class SignupControllerIT {
     private final String EMAIL_UPPER_CASE = "EMAIL_ADDRESS@GOOGLE.COM";
     private final String EMAIL_LOWER_CASE = EMAIL_UPPER_CASE.toLowerCase();
 
-    private SignupAccountModel model = new SignupAccountModel(
+    private final SignupAccountModel model = new SignupAccountModel(
         "model_upper_case",
         EMAIL_UPPER_CASE, EMAIL_UPPER_CASE,
         "password","password",
         "firstName", "lastName");
 
-    private SignupAccountModel anotherModelWithSameButLowerCaseEmail = new SignupAccountModel(
+    private final SignupAccountModel anotherModelWithSameButLowerCaseEmail = new SignupAccountModel(
         "model_lower_case",
         EMAIL_LOWER_CASE, EMAIL_LOWER_CASE,
         "another_password", "another_password",
@@ -70,6 +70,8 @@ class SignupControllerIT {
 
     @Test
     void createAccountWithIgnoreEmailCase() throws Exception {
+        assertThat(accountRepository.count()).isEqualTo(0L);
+
         mockMvc.perform(post("/signup")
             .param("username", model.getUsername())
             .param("email", model.getEmail())
@@ -79,9 +81,9 @@ class SignupControllerIT {
             .param("firstName", model.getFirstName())
             .param("lastName", model.getLastName())
             .with(csrf()));
-        assertThat(accountRepository.findAccountByUsername("model_upper_case")).isNotEmpty();
-        assertThat(accountRepository.findAccountByUsername("model_upper_case").orElseThrow().getEmail())
-            .isEqualTo(EMAIL_LOWER_CASE);
+        assertThat(accountRepository.findAccountByEmail(EMAIL_UPPER_CASE)).isEmpty();
+        assertThat(accountRepository.findAccountByEmail(EMAIL_LOWER_CASE)).isNotEmpty();
+        assertThat(accountRepository.count()).isEqualTo(1L);
 
         mockMvc.perform(post("/signup")
             .param("username", anotherModelWithSameButLowerCaseEmail.getUsername())
@@ -92,7 +94,7 @@ class SignupControllerIT {
             .param("firstName", anotherModelWithSameButLowerCaseEmail.getFirstName())
             .param("lastName", anotherModelWithSameButLowerCaseEmail.getLastName())
             .with(csrf()));
-        assertThat(accountRepository.findAccountByUsername("model_lower_case")).isEmpty();
+        assertThat(accountRepository.count()).isEqualTo(1L);
     }
 
     @Test
@@ -129,10 +131,9 @@ class SignupControllerIT {
 
     }
 
-    //my add
     @Test
     void createAccountWithDifferentCaseInEmailAndConfirmation() throws Exception {
-        assertThat(accountRepository.findAccountByUsername(model.getUsername())).isEmpty();
+        assertThat(accountRepository.findAccountByEmail(EMAIL_LOWER_CASE)).isEmpty();
 
         mockMvc.perform(post("/signup")
             .param("username", model.getUsername())
@@ -143,10 +144,7 @@ class SignupControllerIT {
             .param("firstName", model.getFirstName())
             .param("lastName", model.getLastName())
             .with(csrf()));
-        Optional<Account> addedAcc = accountRepository.findAccountByUsername(model.getUsername());
-        assertThat(addedAcc).isNotEmpty();
-        assertThat(addedAcc.orElseThrow().getEmail())
-            .isEqualTo(anotherModelWithSameButLowerCaseEmail.getEmail());
+
+        assertThat(accountRepository.findAccountByEmail(EMAIL_LOWER_CASE)).isNotEmpty();
     }
-    //my add end
 }

--- a/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
@@ -93,6 +93,22 @@ class SignupControllerIT {
     }
 
     @Test
+    void createAccountWithDifferentCaseInEmailAndConfirmation() throws Exception {
+        mockMvc.perform(post("/signup")
+            .param("username", model.getUsername())
+            .param("email", model.getEmail())
+            .param("confirmEmail", anotherModelWithSameButLowerCaseEmail.getEmail())
+            .param("password", model.getPassword())
+            .param("confirmPassword", model.getConfirmPassword())
+            .param("firstName", model.getFirstName())
+            .param("lastName", model.getLastName())
+            .with(csrf()));
+        assertThat(accountRepository.findAccountByUsername("model_upper_case")).isNotEmpty();
+        assertThat(accountRepository.findAccountByUsername("model_upper_case").orElseThrow().getEmail())
+            .isEqualTo(anotherModelWithSameButLowerCaseEmail.getEmail());
+    }
+
+    @Test
     void createAccountWithWrongEmailDomain() throws Exception {
         String userName = "testUser";
         String password = "_Qwe1234";

--- a/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
@@ -2,7 +2,6 @@ package io.hexlet.typoreporter.web;
 
 import com.github.database.rider.core.api.configuration.DBUnit;
 import com.github.database.rider.spring.api.DBRider;
-import io.hexlet.typoreporter.domain.account.Account;
 import io.hexlet.typoreporter.repository.AccountRepository;
 import io.hexlet.typoreporter.test.DBUnitEnumPostgres;
 import io.hexlet.typoreporter.web.model.SignupAccountModel;
@@ -17,9 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.containers.PostgreSQLContainer;
-
-import java.util.Optional;
-
 import static com.github.database.rider.core.api.configuration.Orthography.LOWERCASE;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;

--- a/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
@@ -148,36 +148,5 @@ class SignupControllerIT {
         assertThat(addedAcc.orElseThrow().getEmail())
             .isEqualTo(anotherModelWithSameButLowerCaseEmail.getEmail());
     }
-
-    @Test
-    void loginByEmailInAnyCaseSuccess() throws Exception {
-        assertThat(accountRepository.findAccountByEmail(anotherModelWithSameButLowerCaseEmail.getEmail())).isEmpty();
-
-        mockMvc.perform(post("/signup")
-            .param("username", model.getUsername())
-            .param("email", model.getEmail())
-            .param("confirmEmail", model.getEmail())
-            .param("password", model.getPassword())
-            .param("confirmPassword", model.getPassword())
-            .param("firstName", model.getFirstName())
-            .param("lastName", model.getLastName())
-            .with(csrf()));
-        assertThat(accountRepository.findAccountByEmail(anotherModelWithSameButLowerCaseEmail.getEmail())).isNotEmpty();
-
-        mockMvc.perform(post("/login")
-            .param("username", anotherModelWithSameButLowerCaseEmail.getEmail())
-            .param("password", model.getPassword())
-            .with(csrf()))
-            .andExpect(status().isOk());
-
-        mockMvc.perform(post("/logout"))
-            .andExpect(status().isOk());
-
-        mockMvc.perform(post("/login")
-                .param("username", model.getEmail())
-                .param("password", model.getPassword())
-                .with(csrf()))
-            .andExpect(status().isOk());
-    }
     //my add end
 }

--- a/src/test/java/io/hexlet/typoreporter/web/WorkspaceControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/WorkspaceControllerIT.java
@@ -155,15 +155,40 @@ class WorkspaceControllerIT {
         }
     }
 
+    //my add
+//    @ParameterizedTest
+//    @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspacesAndUsersAndTypoStatusRelated")
+//    void getWorkspaceTyposPageFilteredIsSuccessful(final Long wksId, final String username, final String typoStatus) throws Exception {
+//        Workspace workspace = repository.getWorkspaceById(wksId).orElse(null);
+//
+//        var request = get("/workspace/{wksId}/typos", wksId).queryParam("typoStatus", typoStatus);
+//
+//        MockHttpServletResponse response = mockMvc.perform(request
+//                .with(user(username)))
+//            .andExpect(model().attributeExists("wksInfo", "wksName", "typoPage", "availableSizes", "sortProp", "sortDir", "DESC", "ASC", "typoStatus"))
+//            .andReturn().getResponse();
+//
+//        Typo typo = workspace.getTypos().stream()
+//            .filter(t -> !t.getTypoStatus().equals(TypoStatus.valueOf(typoStatus)))
+//            .findFirst().orElse(null);
+//
+//        if (typo != null) {
+//            assertThat(response.getContentAsString()).contains(
+//                typo.getPageUrl(), typo.getReporterName(), typo.getModifiedBy()
+//            );
+//        } else {
+//            fail("No typos without status " + typoStatus);
+//        }
+//    }
     @ParameterizedTest
     @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspacesAndUsersAndTypoStatusRelated")
-    void getWorkspaceTyposPageFilteredIsSuccessful(final Long wksId, final String username, final String typoStatus) throws Exception {
+    void getWorkspaceTyposPageFilteredIsSuccessful(final Long wksId, final String email, final String typoStatus) throws Exception {
         Workspace workspace = repository.getWorkspaceById(wksId).orElse(null);
 
         var request = get("/workspace/{wksId}/typos", wksId).queryParam("typoStatus", typoStatus);
 
         MockHttpServletResponse response = mockMvc.perform(request
-                .with(user(username)))
+                .with(user(email)))
             .andExpect(model().attributeExists("wksInfo", "wksName", "typoPage", "availableSizes", "sortProp", "sortDir", "DESC", "ASC", "typoStatus"))
             .andReturn().getResponse();
 
@@ -179,6 +204,7 @@ class WorkspaceControllerIT {
             fail("No typos without status " + typoStatus);
         }
     }
+    //my add end
 
     @Test
     void getWorkspaceSettingsPageWithoutWksInfo() throws Exception {
@@ -308,7 +334,7 @@ class WorkspaceControllerIT {
 
     @ParameterizedTest
     @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspacesAndUsersRelated")
-    void getWorkspaceUsersPage(final Long wksId, final String username) throws Exception {
+    void getWorkspaceUsersPage(final Long wksId, final String email) throws Exception {
         Workspace workspace = repository.getWorkspaceById(wksId).orElseThrow();
         Set<Account> accounts = new HashSet<>(accountRepository.findAll());
 
@@ -320,15 +346,22 @@ class WorkspaceControllerIT {
 
         MockHttpServletResponse response = mockMvc.perform(
                 get("/workspace/{wksId}/users", wksId)
-                    .with(user(username)))
+                    //my add
+//                    .with(user(username)))
+                    .with(user(email)))
+                    //my add end
             .andExpect(status().isOk())
             .andExpect(model().attributeExists("wksInfo", "wksName", "userPage", "availableSizes", "sortProp", "sortDir", "DESC", "ASC"))
             .andReturn().getResponse();
 
         var html = response.getContentAsString();
         for (var wksRole : workspace.getWorkspaceRoles()) {
-            var email = wksRole.getAccount().getEmail();
-            assertThat(html).contains(email);
+            //my add
+            //            var email = wksRole.getAccount().getEmail();
+//            assertThat(html).contains(email);
+            var userEmail = wksRole.getAccount().getEmail();
+            assertThat(html).contains(userEmail);
+            //my add end
         }
     }
 }

--- a/src/test/java/io/hexlet/typoreporter/web/WorkspaceSettingsControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/WorkspaceSettingsControllerIT.java
@@ -95,16 +95,38 @@ public class WorkspaceSettingsControllerIT {
         assertThat(response.getContentAsString()).contains(apiAccessToken);
     }
 
+    //my add
+//    @ParameterizedTest
+//    @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspaceAndAdminRelated")
+//    void patchWorkspaceTokenIsSuccessful(final Long wksId, final String username) throws Exception {
+//        String previousWksToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
+//            .map(WorkspaceSettings::getApiAccessToken)
+//            .map(UUID::toString)
+//            .orElse(null);
+//
+//        MockHttpServletResponse response = mockMvc.perform(patch("/workspace/{wksId}/token/regenerate", wksId)
+//                .with(user(username))
+//                .with(csrf()))
+//            .andReturn().getResponse();
+//
+//        String newWksToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
+//            .map(WorkspaceSettings::getApiAccessToken)
+//            .map(UUID::toString)
+//            .orElse(null);
+//
+//        assertThat(previousWksToken).isNotEqualTo(newWksToken);
+//        assertThat(response.getRedirectedUrl()).isEqualTo("/workspace/" + wksId.toString() + "/settings");
+//    }
     @ParameterizedTest
     @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspaceAndAdminRelated")
-    void patchWorkspaceTokenIsSuccessful(final Long wksId, final String username) throws Exception {
+    void patchWorkspaceTokenIsSuccessful(final Long wksId, final String email) throws Exception {
         String previousWksToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
             .map(WorkspaceSettings::getApiAccessToken)
             .map(UUID::toString)
             .orElse(null);
 
         MockHttpServletResponse response = mockMvc.perform(patch("/workspace/{wksId}/token/regenerate", wksId)
-                .with(user(username))
+                .with(user(email))
                 .with(csrf()))
             .andReturn().getResponse();
 
@@ -116,17 +138,40 @@ public class WorkspaceSettingsControllerIT {
         assertThat(previousWksToken).isNotEqualTo(newWksToken);
         assertThat(response.getRedirectedUrl()).isEqualTo("/workspace/" + wksId.toString() + "/settings");
     }
+    //my add end
 
+    //my add
+//    @ParameterizedTest
+//    @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspaceAndNotAdminRelated")
+//    void patchWorkspaceTokenWithNoRights(final Long wksId, final String username)  throws Exception {
+//        String previousWksToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
+//            .map(WorkspaceSettings::getApiAccessToken)
+//            .map(UUID::toString)
+//            .orElse(null);
+//
+//        MockHttpServletResponse response = mockMvc.perform(patch("/workspace/{wksId}/token/regenerate", wksId.toString())
+//                .with(user(username))
+//                .with(csrf()))
+//            .andReturn().getResponse();
+//
+//        String newWksToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
+//            .map(WorkspaceSettings::getApiAccessToken)
+//            .map(UUID::toString)
+//            .orElse(null);
+//
+//        assertThat(previousWksToken).isEqualTo(newWksToken);
+//        assertThat(response.getRedirectedUrl()).isEqualTo("/workspaces");
+//    }
     @ParameterizedTest
     @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspaceAndNotAdminRelated")
-    void patchWorkspaceTokenWithNoRights(final Long wksId, final String username)  throws Exception {
+    void patchWorkspaceTokenWithNoRights(final Long wksId, final String email)  throws Exception {
         String previousWksToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
             .map(WorkspaceSettings::getApiAccessToken)
             .map(UUID::toString)
             .orElse(null);
 
         MockHttpServletResponse response = mockMvc.perform(patch("/workspace/{wksId}/token/regenerate", wksId.toString())
-                .with(user(username))
+                .with(user(email))
                 .with(csrf()))
             .andReturn().getResponse();
 
@@ -138,4 +183,5 @@ public class WorkspaceSettingsControllerIT {
         assertThat(previousWksToken).isEqualTo(newWksToken);
         assertThat(response.getRedirectedUrl()).isEqualTo("/workspaces");
     }
+    //my add end
 }

--- a/src/test/java/io/hexlet/typoreporter/web/WorkspaceSettingsControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/WorkspaceSettingsControllerIT.java
@@ -63,7 +63,7 @@ public class WorkspaceSettingsControllerIT {
 
     @ParameterizedTest
     @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspacesAndUsersRelated")
-    void getWorkspaceIntegrationPageIsSuccessful(final Long wksId, final String username) throws Exception {
+    void getWorkspaceIntegrationPageIsSuccessful(final Long wksId, final String email) throws Exception {
         final var apiAccessToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
             .map(s -> s.getId() + ":" + s.getApiAccessToken())
             .map(String::getBytes)
@@ -71,7 +71,7 @@ public class WorkspaceSettingsControllerIT {
             .orElse(null);
 
         MockHttpServletResponse response = mockMvc.perform(get("/workspace/{wksId}/integration", wksId.toString())
-                .with(user(username)))
+                .with(user(email)))
             .andExpect(model().attributeExists("wksBasicToken"))
             .andReturn().getResponse();
 
@@ -95,28 +95,6 @@ public class WorkspaceSettingsControllerIT {
         assertThat(response.getContentAsString()).contains(apiAccessToken);
     }
 
-    //my add
-//    @ParameterizedTest
-//    @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspaceAndAdminRelated")
-//    void patchWorkspaceTokenIsSuccessful(final Long wksId, final String username) throws Exception {
-//        String previousWksToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
-//            .map(WorkspaceSettings::getApiAccessToken)
-//            .map(UUID::toString)
-//            .orElse(null);
-//
-//        MockHttpServletResponse response = mockMvc.perform(patch("/workspace/{wksId}/token/regenerate", wksId)
-//                .with(user(username))
-//                .with(csrf()))
-//            .andReturn().getResponse();
-//
-//        String newWksToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
-//            .map(WorkspaceSettings::getApiAccessToken)
-//            .map(UUID::toString)
-//            .orElse(null);
-//
-//        assertThat(previousWksToken).isNotEqualTo(newWksToken);
-//        assertThat(response.getRedirectedUrl()).isEqualTo("/workspace/" + wksId.toString() + "/settings");
-//    }
     @ParameterizedTest
     @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspaceAndAdminRelated")
     void patchWorkspaceTokenIsSuccessful(final Long wksId, final String email) throws Exception {
@@ -138,30 +116,7 @@ public class WorkspaceSettingsControllerIT {
         assertThat(previousWksToken).isNotEqualTo(newWksToken);
         assertThat(response.getRedirectedUrl()).isEqualTo("/workspace/" + wksId.toString() + "/settings");
     }
-    //my add end
 
-    //my add
-//    @ParameterizedTest
-//    @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspaceAndNotAdminRelated")
-//    void patchWorkspaceTokenWithNoRights(final Long wksId, final String username)  throws Exception {
-//        String previousWksToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
-//            .map(WorkspaceSettings::getApiAccessToken)
-//            .map(UUID::toString)
-//            .orElse(null);
-//
-//        MockHttpServletResponse response = mockMvc.perform(patch("/workspace/{wksId}/token/regenerate", wksId.toString())
-//                .with(user(username))
-//                .with(csrf()))
-//            .andReturn().getResponse();
-//
-//        String newWksToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
-//            .map(WorkspaceSettings::getApiAccessToken)
-//            .map(UUID::toString)
-//            .orElse(null);
-//
-//        assertThat(previousWksToken).isEqualTo(newWksToken);
-//        assertThat(response.getRedirectedUrl()).isEqualTo("/workspaces");
-//    }
     @ParameterizedTest
     @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspaceAndNotAdminRelated")
     void patchWorkspaceTokenWithNoRights(final Long wksId, final String email)  throws Exception {
@@ -183,5 +138,4 @@ public class WorkspaceSettingsControllerIT {
         assertThat(previousWksToken).isEqualTo(newWksToken);
         assertThat(response.getRedirectedUrl()).isEqualTo("/workspaces");
     }
-    //my add end
 }


### PR DESCRIPTION
Авторизация по почте вместо имени пользователя теперь выполняется.
При регистрации нового юзера, входе в систему и смене пароля у юзера теперь не учитывается регистр символов в email. Тесты на это запилил.
Шаблончик страницы ввода логина/пароля тоже поправил.