### PR TITLE
Убрать подтверждение почты при регистрации и изменении аккаунта

### DIFF
--- a/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchConsiderCase.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchConsiderCase.java
@@ -21,11 +21,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <br>
  * Example, compare more than 1 pair of fields:
  * <br>
- * {@code @FieldMatch.List({
- *
- * @FieldMatch(first = "password", second = "confirmPassword", message = "The password fields must match"),
- * @FieldMatch(first = "email", second = "confirmEmail", message = "The email fields must match")
- * })}
+ * {@code @FieldMatchConsiderCase(first = "password", second = "confirmPassword", message = "The password and it confirmation must match")}
  */
 @Constraint(validatedBy = FieldMatchConsiderCaseValidator.class)
 public @interface FieldMatchConsiderCase {

--- a/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchIgnoreCase.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/FieldMatchIgnoreCase.java
@@ -21,11 +21,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <br>
  * Example, compare more than 1 pair of fields:
  * <br>
- * {@code @FieldMatch.List({
- *
- * @FieldMatch(first = "password", second = "confirmPassword", message = "The password fields must match"),
- * @FieldMatch(first = "email", second = "confirmEmail", message = "The email fields must match")
- * })}
+ * {@code @FieldMatchConsiderCase(first = "password", second = "confirmPassword", message = "The password and it confirmation must match")}
  */
 @Target({TYPE, ANNOTATION_TYPE})
 @Retention(RUNTIME)

--- a/src/main/java/io/hexlet/typoreporter/service/dto/account/UpdateProfile.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/account/UpdateProfile.java
@@ -1,7 +1,6 @@
 package io.hexlet.typoreporter.service.dto.account;
 
 import io.hexlet.typoreporter.domain.account.constraint.AccountUsername;
-import io.hexlet.typoreporter.service.dto.FieldMatchConsiderCase;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -12,9 +11,6 @@ import lombok.experimental.Accessors;
 @Getter
 @Setter
 @Accessors(chain = true)
-//my add
-//@FieldMatchConsiderCase(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
-//my add end
 public class UpdateProfile {
 
     @AccountUsername
@@ -22,11 +18,6 @@ public class UpdateProfile {
 
     @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
     private String email;
-
-    //my add
-//    @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
-//    private String confirmEmail;
-    //my add end
 
     @NotBlank
     @Size(min = 1, max = 50)

--- a/src/main/java/io/hexlet/typoreporter/service/dto/account/UpdateProfile.java
+++ b/src/main/java/io/hexlet/typoreporter/service/dto/account/UpdateProfile.java
@@ -12,7 +12,9 @@ import lombok.experimental.Accessors;
 @Getter
 @Setter
 @Accessors(chain = true)
-@FieldMatchConsiderCase(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
+//my add
+//@FieldMatchConsiderCase(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
+//my add end
 public class UpdateProfile {
 
     @AccountUsername
@@ -21,8 +23,10 @@ public class UpdateProfile {
     @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
     private String email;
 
-    @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
-    private String confirmEmail;
+    //my add
+//    @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
+//    private String confirmEmail;
+    //my add end
 
     @NotBlank
     @Size(min = 1, max = 50)

--- a/src/main/java/io/hexlet/typoreporter/web/model/SignupAccountModel.java
+++ b/src/main/java/io/hexlet/typoreporter/web/model/SignupAccountModel.java
@@ -22,7 +22,9 @@ import lombok.ToString;
 //    @FieldMatch(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
 //})
 @FieldMatchConsiderCase(first = "password", second = "confirmPassword", message = "The password and it confirmation must match")
-@FieldMatchIgnoreCase(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
+//my add
+//@FieldMatchIgnoreCase(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
+//my add end
 
 @ToString
 public class SignupAccountModel {
@@ -33,8 +35,10 @@ public class SignupAccountModel {
     @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
     private String email;
 
-    @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
-    private String confirmEmail;
+    //my add
+//    @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
+//    private String confirmEmail;
+    //my add end
 
     @AccountPassword
     @ToString.Exclude

--- a/src/main/java/io/hexlet/typoreporter/web/model/SignupAccountModel.java
+++ b/src/main/java/io/hexlet/typoreporter/web/model/SignupAccountModel.java
@@ -17,15 +17,7 @@ import lombok.ToString;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-//@FieldMatch.List({
-//    @FieldMatch(first = "password", second = "confirmPassword", message = "The password and it confirmation must match"),
-//    @FieldMatch(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
-//})
 @FieldMatchConsiderCase(first = "password", second = "confirmPassword", message = "The password and it confirmation must match")
-//my add
-//@FieldMatchIgnoreCase(first = "email", second = "confirmEmail", message = "The email \"{0}\" and it confirmation \"{1}\" must match")
-//my add end
-
 @ToString
 public class SignupAccountModel {
 
@@ -34,11 +26,6 @@ public class SignupAccountModel {
 
     @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
     private String email;
-
-    //my add
-//    @Email(regexp = "^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$", message = "The email \"{0}\" incorrect")
-//    private String confirmEmail;
-    //my add end
 
     @AccountPassword
     @ToString.Exclude

--- a/src/main/resources/templates/account/prof-update.html
+++ b/src/main/resources/templates/account/prof-update.html
@@ -35,13 +35,6 @@
                     <label for="inputEmail" th:text="#{email}"></label>
                     <div class="invalid-feedback" th:each="err : ${#fields.errors('email')}" th:text="${err}"></div>
                 </div>
-                <div class="form-floating mb-3">
-                    <input class="form-control" id="inputConfirmEmail" placeholder="p"
-                           th:classappend="${!#fields.hasErrors('confirmEmail') && formModified ? 'is-valid' : ''}"
-                           th:errorclass="is-invalid" th:field="*{confirmEmail}" type="email">
-                    <label for="inputConfirmEmail" th:text="#{email.confirm}"></label>
-                    <div class="invalid-feedback" th:each="err : ${#fields.errors('confirmEmail')}" th:text="${err}"></div>
-                </div>
                 <button class="btn btn-primary" type="submit" th:text="#{btn.save}"></button>
                 <a class="btn btn-secondary" th:href="@{/account}" th:text="#{btn.close}"></a>
             </form>

--- a/src/main/resources/templates/account/signup.html
+++ b/src/main/resources/templates/account/signup.html
@@ -29,17 +29,6 @@
                     </div>
                 </div>
 
-                <!--div class="form-floating mb-3">
-                    <input id="inputConfirmEmail" placeholder="p" type="email" th:field="*{confirmEmail}"
-                           class="form-control"
-                           th:classappend="${!#fields.hasErrors('confirmEmail') && formModified}? 'is-valid'"
-                           th:errorclass="is-invalid">
-                    <label for="inputConfirmEmail" th:text="#{email.confirm}"></label>
-                    <div class="alert alert-danger" th:if="${#fields.hasErrors('confirmEmail')}">
-                        <p th:each="err : ${#fields.errors('confirmEmail')}" th:text="${err}"></p>
-                    </div>
-                </div-->
-
                 <div class="form-floating mb-3">
                     <input id="inputFirstName" placeholder="p" type="text" th:field="*{firstName}"
                            class="form-control"

--- a/src/main/resources/templates/account/signup.html
+++ b/src/main/resources/templates/account/signup.html
@@ -29,7 +29,7 @@
                     </div>
                 </div>
 
-                <div class="form-floating mb-3">
+                <!--div class="form-floating mb-3">
                     <input id="inputConfirmEmail" placeholder="p" type="email" th:field="*{confirmEmail}"
                            class="form-control"
                            th:classappend="${!#fields.hasErrors('confirmEmail') && formModified}? 'is-valid'"
@@ -38,7 +38,7 @@
                     <div class="alert alert-danger" th:if="${#fields.hasErrors('confirmEmail')}">
                         <p th:each="err : ${#fields.errors('confirmEmail')}" th:text="${err}"></p>
                     </div>
-                </div>
+                </div-->
 
                 <div class="form-floating mb-3">
                     <input id="inputFirstName" placeholder="p" type="text" th:field="*{firstName}"

--- a/src/test/java/io/hexlet/typoreporter/web/AccountControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/AccountControllerIT.java
@@ -57,7 +57,6 @@ public class AccountControllerIT {
         mockMvc.perform(post("/signup")
             .param("username", userName)
             .param("email", correctEmailDomain)
-            .param("confirmEmail", correctEmailDomain)
             .param("password", password)
             .param("confirmPassword", password)
             .param("firstName", userName)
@@ -71,7 +70,6 @@ public class AccountControllerIT {
         mockMvc.perform(post("/account/update")
             .param("username", userName)
             .param("email", wrongEmailDomain)
-            .param("confirmEmail", wrongEmailDomain)
             .param("password", password)
             .param("confirmPassword", password)
             .param("firstName", userName)
@@ -93,7 +91,6 @@ public class AccountControllerIT {
         mockMvc.perform(post("/signup")
             .param("username", username)
             .param("email", emailMixedCase)
-            .param("confirmEmail", emailMixedCase)
             .param("password", password)
             .param("confirmPassword", password)
             .param("firstName", username)
@@ -106,7 +103,6 @@ public class AccountControllerIT {
             .param("lastName", username)
             .param("username", username)
             .param("email", emailUpperCase)
-            .param("confirmEmail", emailUpperCase)
             .with(csrf()));
         assertThat(accountRepository.findAccountByEmail(emailUpperCase)).isEmpty();
         assertThat(accountRepository.findAccountByEmail(emailLowerCase)).isNotEmpty();

--- a/src/test/java/io/hexlet/typoreporter/web/LoginIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/LoginIT.java
@@ -53,7 +53,7 @@ class LoginIT {
 
     private SignupAccountModel model = new SignupAccountModel(
         "model_upper_case",
-        EMAIL_UPPER_CASE, EMAIL_UPPER_CASE,
+        EMAIL_UPPER_CASE,
         "password","password",
         "firstName", "lastName");
 
@@ -64,7 +64,6 @@ class LoginIT {
         mockMvc.perform(post("/signup")
             .param("username", model.getUsername())
             .param("email", model.getEmail())
-            .param("confirmEmail", model.getEmail())
             .param("password", model.getPassword())
             .param("confirmPassword", model.getPassword())
             .param("firstName", model.getFirstName())

--- a/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
@@ -52,17 +52,24 @@ class SignupControllerIT {
     private final String EMAIL_UPPER_CASE = "EMAIL_ADDRESS@GOOGLE.COM";
     private final String EMAIL_LOWER_CASE = EMAIL_UPPER_CASE.toLowerCase();
 
+    //my add
+//    private final SignupAccountModel model = new SignupAccountModel(
+//        "model_upper_case",
+//        EMAIL_UPPER_CASE, EMAIL_UPPER_CASE,
+//        "password","password",
+//        "firstName", "lastName");
     private final SignupAccountModel model = new SignupAccountModel(
         "model_upper_case",
-        EMAIL_UPPER_CASE, EMAIL_UPPER_CASE,
+        EMAIL_UPPER_CASE,
         "password","password",
         "firstName", "lastName");
 
-    private final SignupAccountModel anotherModelWithSameButLowerCaseEmail = new SignupAccountModel(
-        "model_lower_case",
-        EMAIL_LOWER_CASE, EMAIL_LOWER_CASE,
-        "another_password", "another_password",
-        "another_firstName", "another_lastName");
+//    private final SignupAccountModel anotherModelWithSameButLowerCaseEmail = new SignupAccountModel(
+//        "model_lower_case",
+//        EMAIL_LOWER_CASE, EMAIL_LOWER_CASE,
+//        "another_password", "another_password",
+//        "another_firstName", "another_lastName");
+    //my add end
 
     @Test
     void createAccountWithIgnoreEmailCase() throws Exception {

--- a/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/SignupControllerIT.java
@@ -52,24 +52,17 @@ class SignupControllerIT {
     private final String EMAIL_UPPER_CASE = "EMAIL_ADDRESS@GOOGLE.COM";
     private final String EMAIL_LOWER_CASE = EMAIL_UPPER_CASE.toLowerCase();
 
-    //my add
-//    private final SignupAccountModel model = new SignupAccountModel(
-//        "model_upper_case",
-//        EMAIL_UPPER_CASE, EMAIL_UPPER_CASE,
-//        "password","password",
-//        "firstName", "lastName");
     private final SignupAccountModel model = new SignupAccountModel(
         "model_upper_case",
         EMAIL_UPPER_CASE,
         "password","password",
         "firstName", "lastName");
 
-//    private final SignupAccountModel anotherModelWithSameButLowerCaseEmail = new SignupAccountModel(
-//        "model_lower_case",
-//        EMAIL_LOWER_CASE, EMAIL_LOWER_CASE,
-//        "another_password", "another_password",
-//        "another_firstName", "another_lastName");
-    //my add end
+        private final SignupAccountModel anotherModelWithSameButLowerCaseEmail = new SignupAccountModel(
+        "model_lower_case",
+        EMAIL_LOWER_CASE,
+        "another_password", "another_password",
+        "another_firstName", "another_lastName");
 
     @Test
     void createAccountWithIgnoreEmailCase() throws Exception {
@@ -78,7 +71,6 @@ class SignupControllerIT {
         mockMvc.perform(post("/signup")
             .param("username", model.getUsername())
             .param("email", model.getEmail())
-            .param("confirmEmail", model.getEmail())
             .param("password", model.getPassword())
             .param("confirmPassword", model.getConfirmPassword())
             .param("firstName", model.getFirstName())
@@ -91,7 +83,6 @@ class SignupControllerIT {
         mockMvc.perform(post("/signup")
             .param("username", anotherModelWithSameButLowerCaseEmail.getUsername())
             .param("email", anotherModelWithSameButLowerCaseEmail.getEmail())
-            .param("confirmEmail", anotherModelWithSameButLowerCaseEmail.getEmail())
             .param("password", anotherModelWithSameButLowerCaseEmail.getPassword())
             .param("confirmPassword", anotherModelWithSameButLowerCaseEmail.getConfirmPassword())
             .param("firstName", anotherModelWithSameButLowerCaseEmail.getFirstName())
@@ -108,7 +99,6 @@ class SignupControllerIT {
         mockMvc.perform(post("/signup")
             .param("username", userName)
             .param("email", wrongEmailDomain)
-            .param("confirmEmail", wrongEmailDomain)
             .param("password", password)
             .param("confirmPassword", password)
             .param("firstName", userName)
@@ -124,7 +114,6 @@ class SignupControllerIT {
         mockMvc.perform(post("/signup")
             .param("username", userName)
             .param("email", email)
-            .param("confirmEmail", email)
             .param("password", wrongPass)
             .param("confirmPassword", wrongPass)
             .param("firstName", userName)
@@ -132,22 +121,5 @@ class SignupControllerIT {
             .with(csrf())).andExpect((status().isFound()));
         assertThat(accountRepository.findAccountByEmail(email)).isEmpty();
 
-    }
-
-    @Test
-    void createAccountWithDifferentCaseInEmailAndConfirmation() throws Exception {
-        assertThat(accountRepository.findAccountByEmail(EMAIL_LOWER_CASE)).isEmpty();
-
-        mockMvc.perform(post("/signup")
-            .param("username", model.getUsername())
-            .param("email", model.getEmail())
-            .param("confirmEmail", anotherModelWithSameButLowerCaseEmail.getEmail())
-            .param("password", model.getPassword())
-            .param("confirmPassword", model.getConfirmPassword())
-            .param("firstName", model.getFirstName())
-            .param("lastName", model.getLastName())
-            .with(csrf()));
-
-        assertThat(accountRepository.findAccountByEmail(EMAIL_LOWER_CASE)).isNotEmpty();
     }
 }


### PR DESCRIPTION
Подтверждение почты убрал.
Тесты подправил.
Потыкать можно [тут](https://hexlet-correction-r29m.onrender.com/signup?lang=en).