### PR TITLE
Update index.js to fix widget comment section paddings

### DIFF
--- a/src/widget/index.js
+++ b/src/widget/index.js
@@ -54,7 +54,7 @@ const generateModalStyles = () => {
     margin-bottom: 1rem;
     border: 1px solid #ccc;
     flex-shrink: 0;
-    padding-right: 8px;
+    padding: 5px;
   }
 
   #hexlet-correction-modal_ReportTypo-name {


### PR DESCRIPTION
Поправил паддинги у поля для ввода комментария в виджете, привёл из в единообразие с паддингами ввода email

Before:
![before](https://github.com/Hexlet/hexlet-correction/assets/29205112/192d7100-f1db-46b6-88d3-6f54be0b8f1e)

After:
![after](https://github.com/Hexlet/hexlet-correction/assets/29205112/e04b0caf-b633-4d1e-87a0-c3e750bf815f)