### PR TITLE
Update widget's typo selection appearance

### DIFF
--- a/src/widget/index.js
+++ b/src/widget/index.js
@@ -68,10 +68,9 @@ const generateModalStyles = () => {
   }
 
   #hexlet-correction-modal_ReportTypo-highlight {
-    text-decoration: underline;
-    color: black;
-    font-weight: 700;
-    margin: 0 10px;
+    color: white;
+    background-color: royalblue;
+    padding: 1px 0 3px 0;
   }
 
   #hexlet-correction-modal_question {
@@ -205,7 +204,7 @@ const renderModal = (elements, state) => {
   if (state.modalShown) {
     elements.modalEl.style.display = 'block';
     const { textBeforeTypo, textTypo, textAfterTypo } = state.data;
-    elements.selectedTextEl.innerHTML = `${textBeforeTypo}<u id="hexlet-correction-modal_ReportTypo-highlight">${textTypo}</u>${textAfterTypo}`;
+    elements.selectedTextEl.innerHTML = `${textBeforeTypo}<span id="hexlet-correction-modal_ReportTypo-highlight">${textTypo}</span>${textAfterTypo}`;
     elements.inputName.value = state.data.reporterName !== '' ? state.data.reporterName : state.options.userName;
     elements.commentEl.value = state.data.reporterComment;
     elements.commentEl.focus();


### PR DESCRIPTION
Показалось, что более интуитивно и симпатично будет выглядеть подсвечивание опечатки в фрагменте так же, как это выглядит, когда ты просто выделяешь текст
Before:
![image](https://github.com/Hexlet/hexlet-correction/assets/29205112/25ddece5-8b7f-4476-9da2-cfa78b1dfd15)

After:
![feature](https://github.com/Hexlet/hexlet-correction/assets/29205112/fd5978fa-7acb-4eb8-a801-51835c019028)
