### PR TITLE
Fix widget selection algorithm

### DIFF
--- a/src/widget/index.js
+++ b/src/widget/index.js
@@ -305,14 +305,16 @@ const handleTypoReporter = (options) => {
       const { focusNode } = selection;
       const { focusOffset } = selection;
       const maxLength = 50;
-      const start = Math.max(anchorOffset - maxLength, 0);
-      const end = Math.min(focusOffset + maxLength, anchorNode.length);
       state.data.textTypo = selection.toString();
 
       if(isSelectionLeftToRight(selection)) {
+        const start = Math.max(anchorOffset - maxLength, 0);
+        const end = Math.min(focusOffset + maxLength, anchorNode.length);
         state.data.textBeforeTypo = anchorNode.textContent.substring(start, anchorOffset);
         state.data.textAfterTypo = anchorNode.substringData(focusOffset, end - focusOffset);
       } else {
+        const start = Math.max(focusOffset  - maxLength, 0);
+        const end = Math.min(anchorOffset + maxLength, anchorNode.length);
         state.data.textBeforeTypo = anchorNode.textContent.substring(start, focusOffset);
         state.data.textAfterTypo = anchorNode.substringData(anchorOffset, end - anchorOffset);
       }


### PR DESCRIPTION
Обнаружил баг, который проявлялся только при определённом количестве выделенных символов и положении выделения относительно параграфа:
![image](https://github.com/Hexlet/hexlet-correction/assets/29205112/6e021bf8-069b-4755-84d8-50d0d93b6849)

Проблема была в том, что в зависимости от направления выделения, иначе высчитывать нужно также и start вместе с end. Правлю свои же недочёты :)