### PR TITLE
[#293] Add russian translate to email-placeholder at workspace->users

### DIFF
--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -66,6 +66,7 @@ wks.placeholder.descr=Workspace Description
 wks.info=Info
 wks.typos=Typos
 wks.users=Users
+wks.users.email-placeholder=Enter user email. For example: hexlet@gmail.com
 wks.settings=Settings
 wks.urls=URLs
 wks.integration=Integration

--- a/src/main/resources/messages_ru.properties
+++ b/src/main/resources/messages_ru.properties
@@ -71,6 +71,7 @@ wks.placeholder.descr=Описание Пространства
 wks.info=Информация
 wks.typos=Опечатки
 wks.users=Пользователи
+wks.users.email-placeholder=Введите адрес электронной почты пользователя. Например: hexlet@gmail.com
 wks.settings=Настройки
 wks.urls=Домены
 wks.integration=Интеграция

--- a/src/main/resources/templates/workspace/wks-users.html
+++ b/src/main/resources/templates/workspace/wks-users.html
@@ -24,7 +24,7 @@
                 <form method="POST" th:action="@{'/workspace/' + ${wksId} + '/users'}" th:object="${inputEmail}">
                     <div class="form-group">
                         <input type="email" class="form-control" id="inputUserEmail"
-                               placeholder="Enter user email. For example: hexlet@gmail.com" th:field="*{email}"
+                               th:placeholder="#{wks.users.email-placeholder}" th:field="*{email}"
                                th:classappend="${!#fields.hasErrors('email') && formModified}? 'is-valid'"
                                th:errorclass="is-invalid" required>
                         <div class="invalid-feedback" th:if="${#fields.hasErrors('email')}">


### PR DESCRIPTION
Fix issue#293. Add translate for email-palceholder at workspace->users to 'messages_en.properties' and 'messages_ru.properties'.