### PR TITLE
[#254] Add workspace name on Integration page (with test)

### DIFF
--- a/src/main/java/io/hexlet/typoreporter/controller/WorkspaceSettingsController.java
+++ b/src/main/java/io/hexlet/typoreporter/controller/WorkspaceSettingsController.java
@@ -10,7 +10,6 @@ import io.hexlet.typoreporter.service.WorkspaceService;
 import io.hexlet.typoreporter.service.WorkspaceSettingsService;
 import io.hexlet.typoreporter.service.dto.typo.TypoInfo;
 import io.hexlet.typoreporter.service.dto.workspace.AllowedUrlDTO;
-import io.hexlet.typoreporter.service.dto.workspace.WorkspaceInfo;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;

--- a/src/main/java/io/hexlet/typoreporter/controller/WorkspaceSettingsController.java
+++ b/src/main/java/io/hexlet/typoreporter/controller/WorkspaceSettingsController.java
@@ -168,9 +168,9 @@ public class WorkspaceSettingsController {
     @GetMapping("/integration")
     @PreAuthorize(IS_USER_RELATED_TO_WKS)
     public String getWorkspaceIntegrationPage(Model model, @PathVariable Long wksId, HttpServletRequest req) {
-        var wksOptional = workspaceService.getWorkspaceInfoById(wksId);
+        var wksOptional = workspaceService.getWorkspaceInfoById(wksId).orElse(null);
 
-        if (wksOptional.isEmpty()) {
+        if (wksOptional == null) {
             //TODO send to error page
             log.error("Workspace with id {} not found", wksId);
             return "redirect:/workspaces";
@@ -178,9 +178,8 @@ public class WorkspaceSettingsController {
 
         addTokenAndUrlToModel(model, wksId, req);
 
-        WorkspaceInfo wksInfo = wksOptional.get();
-        model.addAttribute("wksInfo", wksInfo);
-        model.addAttribute("wksName", wksInfo.name());
+        model.addAttribute("wksInfo", wksOptional);
+        model.addAttribute("wksName", wksOptional.name());
 
         getStatisticDataToModel(model, wksId);
         getLastTypoDataToModel(model, wksId);

--- a/src/main/java/io/hexlet/typoreporter/controller/WorkspaceSettingsController.java
+++ b/src/main/java/io/hexlet/typoreporter/controller/WorkspaceSettingsController.java
@@ -10,6 +10,7 @@ import io.hexlet.typoreporter.service.WorkspaceService;
 import io.hexlet.typoreporter.service.WorkspaceSettingsService;
 import io.hexlet.typoreporter.service.dto.typo.TypoInfo;
 import io.hexlet.typoreporter.service.dto.workspace.AllowedUrlDTO;
+import io.hexlet.typoreporter.service.dto.workspace.WorkspaceInfo;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
@@ -167,13 +168,19 @@ public class WorkspaceSettingsController {
     @GetMapping("/integration")
     @PreAuthorize(IS_USER_RELATED_TO_WKS)
     public String getWorkspaceIntegrationPage(Model model, @PathVariable Long wksId, HttpServletRequest req) {
-        if (!workspaceService.existsWorkspaceById(wksId)) {
+        var wksOptional = workspaceService.getWorkspaceInfoById(wksId);
+
+        if (wksOptional.isEmpty()) {
             //TODO send to error page
             log.error("Workspace with id {} not found", wksId);
             return "redirect:/workspaces";
         }
 
         addTokenAndUrlToModel(model, wksId, req);
+
+        WorkspaceInfo wksInfo = wksOptional.get();
+        model.addAttribute("wksInfo", wksInfo);
+        model.addAttribute("wksName", wksInfo.name());
 
         getStatisticDataToModel(model, wksId);
         getLastTypoDataToModel(model, wksId);

--- a/src/test/java/io/hexlet/typoreporter/web/WorkspaceSettingsControllerIT.java
+++ b/src/test/java/io/hexlet/typoreporter/web/WorkspaceSettingsControllerIT.java
@@ -83,18 +83,25 @@ public class WorkspaceSettingsControllerIT {
     @ParameterizedTest
     @MethodSource("io.hexlet.typoreporter.test.factory.EntitiesFactory#getWorkspacesAndUsersRelated")
     void getWorkspaceIntegrationPageIsSuccessful(final Long wksId, final String email) throws Exception {
-        final var apiAccessToken = workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId)
+        final var workspaces =  workspaceSettingsRepository.getWorkspaceSettingsByWorkspaceId(wksId);
+        final var apiAccessToken = workspaces
             .map(s -> s.getId() + ":" + s.getApiAccessToken())
             .map(String::getBytes)
             .map(Base64.getEncoder()::encodeToString)
             .orElse(null);
 
+        final var wksName = workspaces
+            .map(m -> m.getWorkspace().getName())
+            .orElse(null);
+
         MockHttpServletResponse response = mockMvc.perform(get("/workspace/{wksId}/integration", wksId.toString())
                 .with(user(email)))
-            .andExpect(model().attributeExists("wksBasicToken"))
+            .andExpect(model().attributeExists("wksBasicToken", "wksName"))
             .andReturn().getResponse();
 
         assertThat(response.getContentAsString()).contains(apiAccessToken);
+        assertThat(response.getContentAsString()).contains(wksName);
+
     }
 
     @ParameterizedTest
@@ -213,4 +220,5 @@ public class WorkspaceSettingsControllerIT {
                                                                         WORKSPACE_101_ID);
         assertThat(deletedAllowedUrlOptional).isEmpty();
     }
+
 }


### PR DESCRIPTION
The workspace name is displayed correctly on the Integration page. One of the tests for checking the name of the space on the integration page has also been adjusted.

--
На странице integration корректно отображается имя рабочего пространства. Также скорретирован один из тестов для проверки имени пространства на странице "Интеграция".
![issue254](https://github.com/user-attachments/assets/112cd031-5a03-4575-af17-3c4550b71fb6)
