### PR TITLE
[#153] Add footer to website templates

### DIFF
--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <body class="d-flex min-vh-100">
-<footer th:fragment="footer" class="p-3 bg-dark bg-gradient text-light mt-auto">
+<footer th:fragment="footer" class="p-3 mt-auto border-top">
     <div class="container-xl">
         <div class="row justify-content-lg-around">
             <div class="col-sm-6 col-md-3 col-lg-auto">
                 <a class="text-dark px-0 py-0 text-decoration-none" href="https://ru.hexlet.io">
-                    <p class="mb-2 text-light">© Hexlet</p>
+                    <p class="mb-2">© Hexlet</p>
                 </a>
                 <ul class="nav flex-column">
                     <li class="nav-item">

--- a/src/main/resources/templates/fragments/panels.html
+++ b/src/main/resources/templates/fragments/panels.html
@@ -3,7 +3,7 @@
       xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
 <body>
-<nav aria-label="Main navbar" class="navbar fixed-top navbar-expand-lg navbar-dark bg-dark" th:fragment="mainNavbarTop">
+<nav aria-label="Main navbar" class="navbar fixed-top navbar-expand-lg navbar-dark bg-dark bg-gradient" th:fragment="mainNavbarTop">
     <div class="container">
         <a class="navbar-brand" th:href="@{/workspaces}">FixIT</a>
         <button aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation" class="navbar-toggler"


### PR DESCRIPTION
I checked once again overall application style and propose to improve it a little bit. Now the contrast is too high between navbar, content and footer. It's dark-light-dark now. Usually dark part only one - navbar or footer. So, I propose to make footer light. I think it will look better. By the way, this color scheme is in the file "landing.html", I just didn't implemented it fully when I did previous PR.

Current color scheme:
![Screenshot from 2024-10-11 22-44-00](https://github.com/user-attachments/assets/fa3e77c2-19b3-4c86-a4bd-a69bd850d970)

Proposed color scheme (from "landing.html"):
![Screenshot from 2024-10-11 22-44-10](https://github.com/user-attachments/assets/8d52af14-8bf9-423c-8e86-6b21623c1111)

Demo: https://hexlet-correction-4.onrender.com/